### PR TITLE
fixes #57 clearOnDoubleClick defaults to false in SignaturePadView

### DIFF
--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -21,7 +21,7 @@ fun SignaturePadView(
     penMaxWidth: Dp = 7.dp,
     penColor: Color = Color.Black,
     velocityFilterWeight: Float = 0.9F,
-    clearOnDoubleClick: Boolean = true,
+    clearOnDoubleClick: Boolean = false,
     onReady: (svg: SignaturePadAdapter) -> Unit = {},
     onStartSigning: () -> Unit = {},
     onSigned: () -> Unit = {},


### PR DESCRIPTION
clearOnDoubleClick defaults to false in SignaturePadView