### PR TITLE
Change compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ section:
 Then, include the library as dependency:
 
 ```gradle
-compile 'se.warting.signature:signature-pad:<latest_version>' // jetpack Compose views
+implementation 'se.warting.signature:signature-pad:<latest_version>' // jetpack Compose views
 ```
 or
 ```gradle
-compile 'se.warting.signature:signature-view:<latest_version>' // legacy android views
+implementation 'se.warting.signature:signature-view:<latest_version>' // legacy android views
 ```
 
 ## Usage


### PR DESCRIPTION
Tracked by [ABCD-XXXX](https://github.com/warting/android-signaturepad/issues/ABCD-XXXX)

## This PR...

Makes it easier for users to import the library in to gradle by not using deprecated `compile`

## Considerations and implementation

N/A

### How to test

Not required - README changes only

### Test(s) added 

Not required - README changes only
 
### Screenshots

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |
