### PR TITLE
Support for onSigning() event. Moved instructions from onSinged() to onSigning()

### DIFF
--- a/app/src/main/java/se/warting/signaturepad/ComposeActivity.kt
+++ b/app/src/main/java/se/warting/signaturepad/ComposeActivity.kt
@@ -5,11 +5,7 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -53,6 +49,18 @@ class ComposeActivity : ComponentActivity() {
                                     signaturePadAdapter = it
                                 },
                                 penColor = penColor.value,
+
+
+                                onStartSigning = {
+                                    if (BuildConfig.DEBUG) {
+                                        Log.d("ComposeActivity", "onStartSigning")
+                                    }
+                                },
+                                onSigning = {
+                                    if (BuildConfig.DEBUG) {
+                                        Log.d("ComposeActivity", "onSigning")
+                                    }
+                                },
                                 onSigned = {
                                     if (BuildConfig.DEBUG) {
                                         Log.d("ComposeActivity", "onSigned")
@@ -66,11 +74,7 @@ class ComposeActivity : ComponentActivity() {
                                         )
                                     }
                                 },
-                                onStartSigning = {
-                                    if (BuildConfig.DEBUG) {
-                                        Log.d("ComposeActivity", "onStartSigning")
-                                    }
-                                })
+                            )
                         }
                         Row {
                             Button(onClick = {

--- a/app/src/main/java/se/warting/signaturepad/DataBindingActivity.kt
+++ b/app/src/main/java/se/warting/signaturepad/DataBindingActivity.kt
@@ -23,12 +23,23 @@ class DataBindingActivity : Activity() {
                     .show()
             }
 
+            override fun onSigning() {
+                Toast.makeText(this@DataBindingActivity, "OnSigning", Toast.LENGTH_SHORT)
+                    .show()
+            }
+
             override fun onSigned() {
+                Toast.makeText(this@DataBindingActivity, "OnSigned", Toast.LENGTH_SHORT)
+                    .show()
+
                 binding.saveButton.isEnabled = true
                 binding.clearButton.isEnabled = true
             }
 
             override fun onClear() {
+                Toast.makeText(this@DataBindingActivity, "OnClear", Toast.LENGTH_SHORT)
+                    .show()
+
                 binding.saveButton.isEnabled = false
                 binding.clearButton.isEnabled = false
             }

--- a/app/src/main/java/se/warting/signaturepad/SaveRestoreActivity.kt
+++ b/app/src/main/java/se/warting/signaturepad/SaveRestoreActivity.kt
@@ -5,11 +5,7 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -54,6 +50,16 @@ class SaveRestoreActivity : ComponentActivity() {
                                 onReady = {
                                     signaturePadAdapter = it
                                 },
+                                onStartSigning = {
+                                    if (BuildConfig.DEBUG) {
+                                        Log.d("ComposeActivity", "onStartSigning")
+                                    }
+                                },
+                                onSigning = {
+                                    if (BuildConfig.DEBUG) {
+                                        Log.d("ComposeActivity", "onStartSigning")
+                                    }
+                                },
                                 onSigned = {
                                     if (BuildConfig.DEBUG) {
                                         Log.d("ComposeActivity", "onSigned")
@@ -67,11 +73,7 @@ class SaveRestoreActivity : ComponentActivity() {
                                         )
                                     }
                                 },
-                                onStartSigning = {
-                                    if (BuildConfig.DEBUG) {
-                                        Log.d("ComposeActivity", "onStartSigning")
-                                    }
-                                })
+                            )
                         }
                         Row {
                             Button(onClick = {

--- a/app/src/main/java/se/warting/signaturepad/ViewActivity.kt
+++ b/app/src/main/java/se/warting/signaturepad/ViewActivity.kt
@@ -18,16 +18,30 @@ class ViewActivity : Activity() {
         val mClearButton = findViewById<View>(R.id.clear_button) as Button
         val mSignaturePad = findViewById<View>(R.id.signature_pad) as SignaturePad
         mSignaturePad.setOnSignedListener(object : SignedListener {
+
             override fun onStartSigning() {
                 Toast.makeText(this@ViewActivity, "OnStartSigning", Toast.LENGTH_SHORT).show()
             }
 
+            override fun onSigning() {
+                Toast.makeText(this@ViewActivity, "OnSigning", Toast.LENGTH_SHORT)
+                    .show()
+            }
+
             override fun onSigned() {
+
+                Toast.makeText(this@ViewActivity, "OnSigned", Toast.LENGTH_SHORT)
+                    .show()
+
                 mSaveButton.isEnabled = true
                 mClearButton.isEnabled = true
             }
 
             override fun onClear() {
+
+                Toast.makeText(this@ViewActivity, "OnClear", Toast.LENGTH_SHORT)
+                    .show()
+
                 mSaveButton.isEnabled = false
                 mClearButton.isEnabled = false
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("com.android.tools.build:gradle:7.4.0-rc01")
 
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.4.0-beta04")
+        classpath("com.android.tools.build:gradle:7.3.1")
 
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -24,6 +24,7 @@ fun SignaturePadView(
     clearOnDoubleClick: Boolean = false,
     onReady: (svg: SignaturePadAdapter) -> Unit = {},
     onStartSigning: () -> Unit = {},
+    onSigning: () -> Unit = {},
     onSigned: () -> Unit = {},
     onClear: () -> Unit = {},
 ) {
@@ -34,8 +35,13 @@ fun SignaturePadView(
             // Creates custom view
             SignaturePad(context, null).apply {
                 this.setOnSignedListener(object : SignedListener {
+
                     override fun onStartSigning() {
                         onStartSigning()
+                    }
+
+                    override fun onSigning() {
+                        onSigning()
                     }
 
                     override fun onSigned() {

--- a/signature-view/src/main/java/se/warting/signatureview/utils/SignaturePadBindingAdapter.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/utils/SignaturePadBindingAdapter.kt
@@ -5,25 +5,32 @@ import se.warting.signatureview.views.SignaturePad
 import se.warting.signatureview.views.SignedListener
 
 object SignaturePadBindingAdapter {
+
     @BindingAdapter("onStartSigning")
     fun setOnSignedListener(view: SignaturePad, onStartSigningListener: OnStartSigningListener?) {
-        setOnSignedListener(view, onStartSigningListener, null, null)
+        setOnSignedListener(view, onStartSigningListener, null, null, null)
+    }
+
+    @BindingAdapter("onSigning")
+    fun setOnSigningListener(view: SignaturePad, onSigningListener: OnSigningListener?) {
+        setOnSignedListener(view, null, onSigningListener, null, null)
     }
 
     @BindingAdapter("onSigned")
     fun setOnSignedListener(view: SignaturePad, onSignedListener: OnSignedListener?) {
-        setOnSignedListener(view, null, onSignedListener, null)
+        setOnSignedListener(view, null, null, onSignedListener, null)
     }
 
     @BindingAdapter("onClear")
     fun setOnSignedListener(view: SignaturePad, onClearListener: OnClearListener?) {
-        setOnSignedListener(view, null, null, onClearListener)
+        setOnSignedListener(view, null, null, null, onClearListener)
     }
 
-    @BindingAdapter(value = ["onStartSigning", "onSigned", "onClear"], requireAll = false)
+    @BindingAdapter(value = ["onStartSigning", "onSigning","onSigned", "onClear"], requireAll = false)
     fun setOnSignedListener(
         view: SignaturePad,
         onStartSigningListener: OnStartSigningListener?,
+        onSigningListener: OnSigningListener?,
         onSignedListener: OnSignedListener?,
         onClearListener: OnClearListener?
     ) {
@@ -31,6 +38,10 @@ object SignaturePadBindingAdapter {
             SignedListener {
             override fun onStartSigning() {
                 onStartSigningListener?.onStartSigning()
+            }
+
+            override fun onSigning() {
+                onSigningListener?.onSigning()
             }
 
             override fun onSigned() {
@@ -45,6 +56,10 @@ object SignaturePadBindingAdapter {
 
     interface OnStartSigningListener {
         fun onStartSigning()
+    }
+
+    interface OnSigningListener {
+        fun onSigning()
     }
 
     interface OnSignedListener {

--- a/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
@@ -16,20 +16,19 @@ import android.view.View
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
-import java.util.ArrayList
-import kotlin.math.ceil
-import kotlin.math.max
-import kotlin.math.roundToInt
-import kotlin.math.sqrt
-import se.warting.signatureview.BuildConfig
 import se.warting.signaturecore.Event
 import se.warting.signaturecore.ExperimentalSignatureApi
-import se.warting.signatureview.R
 import se.warting.signaturecore.Signature
+import se.warting.signatureview.BuildConfig
+import se.warting.signatureview.R
 import se.warting.signatureview.utils.Bezier
 import se.warting.signatureview.utils.ControlTimedPoints
 import se.warting.signatureview.utils.SvgBuilder
 import se.warting.signatureview.utils.TimedPoint
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.roundToInt
+import kotlin.math.sqrt
 
 @SuppressWarnings("TooManyFunctions")
 class SignaturePad(context: Context, attrs: AttributeSet?) : View(context, attrs) {
@@ -199,33 +198,42 @@ class SignaturePad(context: Context, attrs: AttributeSet?) : View(context, attrs
 
         when (event.action) {
             MotionEvent.ACTION_DOWN -> {
+
                 points.clear()
                 mLastTouchX = eventX
                 mLastTouchY = eventY
+
                 addTimedPoint(
                     getNewTimedPoint(eventX, eventY, System.currentTimeMillis()),
                     timestamp
                 )
+
                 mSignedListener?.onStartSigning()
                 addTimedPoint(
                     getNewTimedPoint(eventX, eventY, System.currentTimeMillis()),
                     timestamp
                 )
-                makeEmpty(false)
             }
+
             MotionEvent.ACTION_MOVE -> {
                 addTimedPoint(
                     getNewTimedPoint(eventX, eventY, System.currentTimeMillis()),
                     timestamp
                 )
-                makeEmpty(false)
+
+                mSignedListener?.onSigning()
+
             }
+
             MotionEvent.ACTION_UP -> {
                 addTimedPoint(
                     getNewTimedPoint(eventX, eventY, System.currentTimeMillis()),
                     timestamp
                 )
+
+                mSignedListener?.onSigned()
             }
+
             else -> {
                 throw IllegalStateException("Unknown Motion " + event.action)
             }

--- a/signature-view/src/main/java/se/warting/signatureview/views/SignedListener.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/views/SignedListener.kt
@@ -2,6 +2,7 @@ package se.warting.signatureview.views
 
 interface SignedListener {
     fun onStartSigning()
+    fun onSigning()
     fun onSigned()
     fun onClear()
 }


### PR DESCRIPTION
## This PR...
This version supports the onSigning() event to better distinguish the actions to be performed compared to onSigned() which in the previous version was also called during writing and not only at the end.

The Gradle Version is updated to 7.4.0-rc01

### How to test
In debug mode it is possible to view the events through the toasts at the time of writing in the test activities.