### PR TITLE
Support background color for Compose

### DIFF
--- a/signature-pad/api/signature-pad.api
+++ b/signature-pad/api/signature-pad.api
@@ -18,6 +18,6 @@ public final class se/warting/signaturepad/SignaturePadAdapter {
 }
 
 public final class se/warting/signaturepad/SignaturePadViewKt {
-	public static final fun SignaturePadView-s1NOShc (FFJFZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SignaturePadView-P6RUU8Q (Landroidx/compose/ui/Modifier;FFJFZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -1,6 +1,7 @@
 package se.warting.signaturepad
 
 import android.graphics.Bitmap
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -26,10 +27,12 @@ fun SignaturePadView(
     onStartSigning: () -> Unit = {},
     onSigned: () -> Unit = {},
     onClear: () -> Unit = {},
+    background: Color = Color.White
 ) {
     AndroidView(
         modifier = Modifier
-            .fillMaxSize(),
+            .fillMaxSize()
+            .background(background),
         factory = { context ->
             // Creates custom view
             SignaturePad(context, null).apply {

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -1,8 +1,6 @@
 package se.warting.signaturepad
 
 import android.graphics.Bitmap
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -28,7 +26,6 @@ fun SignaturePadView(
     onStartSigning: () -> Unit = {},
     onSigned: () -> Unit = {},
     onClear: () -> Unit = {},
-
 ) {
     AndroidView(
         modifier = modifier,

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -18,6 +18,7 @@ import se.warting.signatureview.views.SignedListener
 @SuppressWarnings("LongParameterList")
 @Composable
 fun SignaturePadView(
+    modifier: Modifier = Modifier,
     penMinWidth: Dp = 3.dp,
     penMaxWidth: Dp = 7.dp,
     penColor: Color = Color.Black,
@@ -27,12 +28,10 @@ fun SignaturePadView(
     onStartSigning: () -> Unit = {},
     onSigned: () -> Unit = {},
     onClear: () -> Unit = {},
-    background: Color = Color.White
+
 ) {
     AndroidView(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(background),
+        modifier = modifier,
         factory = { context ->
             // Creates custom view
             SignaturePad(context, null).apply {


### PR DESCRIPTION
Tracked by [ABCD-XXXX](https://github.com/warting/android-signaturepad/issues/ABCD-XXXX)

## This PR Support background colour for Compose

_My project needs to change the background colour in Jetpack Compose._
I'd add a parameter background at [SignaturePadView](signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt)

## Considerations and implementation

_What technical details should the team pay particular attention to? What unexpected issues did you encounter?_

### How to test

1. _How can others test your changes?_

### Test(s) added 

_Why did you add tests around the areas you did? If none, explain why_

### Screenshots

| Before | After |
| ------ | ----- |
| _![Screenshot_20221222-172311_Signaturepad](https://user-images.githubusercontent.com/16506840/209115197-fcd88432-2026-48d7-970e-3f1622a99076.jpg)_ | _![Screenshot_20221222-172712_Signaturepad](https://user-images.githubusercontent.com/16506840/209115271-b16fafec-7d5a-4331-b422-5989f2ad6a10.jpg)_ |
