### PR TITLE
Add more flexibility for bitmap pen and background coloring

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Button(onClick = {
 * `penMinWidth` - The minimum width of the stroke (default: 3dp).
 * `penMaxWidth` - The maximum width of the stroke (default: 7dp).
 * `penColor` - The color of the stroke (default: Color.BLACK).
+
 * `velocityFilterWeight` - Weight used to modify new velocity based on the previous velocity (
   default: 0.9).
 * `clearOnDoubleClick` - Double click to clear pad (default: false)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Button(onClick = {
 * `penMinWidth` - The minimum width of the stroke (default: 3dp).
 * `penMaxWidth` - The maximum width of the stroke (default: 7dp).
 * `penColor` - The color of the stroke (default: Color.BLACK).
-
 * `velocityFilterWeight` - Weight used to modify new velocity based on the previous velocity (
   default: 0.9).
 * `clearOnDoubleClick` - Double click to clear pad (default: false)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Button(onClick = {
 
 3. Get signature data
 
-* `getSignatureBitmap()` - A signature bitmap with a white background.
-* `getTransparentSignatureBitmap(trimBlankSpace: Boolean = false)` - A signature bitmap with a transparent background. Set `trimBlankSpace = true` to crop the bitmap to the signature bounds, removing surrounding blank space.
-* `getSignatureSvg()` - A signature Scalable Vector Graphics document.
+* `getSignatureBitmap()` - A signature bitmap with a default white background. You can also customize the image's coloring e.g. `getSignatureBitmap(backgroundColor: Int, penColor: Int)`
 
+* `getTransparentSignatureBitmap(trimBlankSpace: Boolean = false)` - A signature bitmap with a transparent background. Set `trimBlankSpace = true` to crop the bitmap to the signature bounds, removing surrounding blank space. You can also customize the image's coloring, e.g. `getTransparentSignatureBitmap(penColor: Int)`
+
+* `getSignatureSvg()` - A signature Scalable Vector Graphics document.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,7 +101,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.activity.compose)
     implementation(libs.androidx.fragment.fragment.compose)
-    implementation("androidx.compose.material:material-icons-extended")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.espresso.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.activity.compose)
     implementation(libs.androidx.fragment.fragment.compose)
+    implementation("androidx.compose.material:material-icons-extended")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.espresso.espresso.core)

--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -64,34 +64,39 @@ fun ComposeSample() {
                 },
             )
         }
-        Row {
-            Button(onClick = {
-                mutableSvg.value = signaturePadAdapter?.getSignatureSvg() ?: ""
-            }) {
-                Text("Save")
-            }
+        Column {
+            Row {
+                Button(onClick = {
+                    mutableSvg.value = signaturePadAdapter?.getSignatureSvg() ?: ""
+                }) {
+                    Text("Save")
+                }
 
-            Button(onClick = {
-                mutableSvg.value = ""
-                signaturePadAdapter?.clear()
-            }) {
-                Text("Clear")
-            }
+                Button(onClick = {
+                    mutableSvg.value = ""
+                    signaturePadAdapter?.clear()
+                }) {
+                    Text("Clear")
+                }
 
-            Button(onClick = {
-                penColor = Color.Red
-            }) {
-                Text("Red")
+                Button(onClick = {
+                    penColor = Color.Red
+                }) {
+                    Text("Red")
+                }
+                Button(onClick = {
+                    penColor = Color.Black
+                }) {
+                    Text("Black")
+                }
             }
-
             Button(onClick = {
-                penColor = Color.Black
+                penColor = Color.White
             }) {
-                Text("Black")
+                Text("White")
             }
+            Text(text = "SVG: " + mutableSvg.value)
         }
-
-        Text(text = "SVG: " + mutableSvg.value)
     }
 }
 

--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -95,6 +95,7 @@ private fun ColorToggleGroup(
 fun ComposeSample() {
     var svg by remember { mutableStateOf("") }
     var savedBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+    var savedTranparentBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
     var adapter by remember { mutableStateOf<SignaturePadAdapter?>(null) }
 
     var penColor by remember { mutableStateOf(Color.Black) }
@@ -181,12 +182,23 @@ fun ComposeSample() {
                         adapter
                             ?.getSignatureBitmap(
                                 backgroundColor = bgColor.toArgb(),
-                                overrideStrokeColor = strokeOverride?.toArgb()
+                                penColor = strokeOverride?.toArgb()
                             )
                             ?.asImageBitmap()
                     } else {
                         adapter
                             ?.getSignatureBitmap()
+                            ?.asImageBitmap()
+                    }
+                    savedTranparentBitmap = if (useOverride) {
+                        adapter
+                            ?.getTransparentSignatureBitmap(
+                                penColor = strokeOverride?.toArgb()
+                            )
+                            ?.asImageBitmap()
+                    } else {
+                        adapter
+                            ?.getTransparentSignatureBitmap()
                             ?.asImageBitmap()
                     }
                 }
@@ -203,18 +215,31 @@ fun ComposeSample() {
                 Text("Clear")
             }
         }
-
+        Text("Bitmap")
         savedBitmap?.let { img ->
             Spacer(Modifier.height(12.dp))
             Image(
                 bitmap = img,
-                contentDescription = "Saved signature",
+                contentDescription = "Signature bitmap",
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(SIGNATURE_PAD_HEIGHT_DP.dp)
                     .border(1.dp, Color.Gray)
             )
         }
+        Text("Transparent Bitmap")
+        savedTranparentBitmap?.let { img ->
+            Spacer(Modifier.height(12.dp))
+            Image(
+                bitmap = img,
+                contentDescription = "Transparent bitmap",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(SIGNATURE_PAD_HEIGHT_DP.dp)
+                    .border(1.dp, Color.Gray)
+            )
+        }
+
 
         Spacer(Modifier.height(12.dp))
         Text("SVG:", style = MaterialTheme.typography.bodyMedium)

--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -206,8 +206,8 @@ fun ComposeSample() {
             }
         )
 
-        Text("Bitmap")
         bmpPair.first?.let {
+            Text("Bitmap")
             Image(
                 it, "Signature", Modifier
                     .fillMaxWidth()
@@ -215,10 +215,9 @@ fun ComposeSample() {
                     .border(1.dp, Color.Gray)
             )
         }
-
         Spacer(Modifier.height(8.dp))
-        Text("Transparent Bitmap")
         bmpPair.second?.let {
+            Text("Transparent Bitmap")
             Image(
                 it, "Transparent", Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -110,7 +110,7 @@ fun ComposeSample() {
             Modifier
                 .height(SIGNATURE_PAD_HEIGHT_DP.dp)
                 .fillMaxWidth()
-                .border(2.dp, Color.Red)
+                .border(2.dp, Color.Gray)
         ) {
             SignaturePadView(
                 onReady = { adapter = it },

--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -2,12 +2,21 @@ package se.warting.signaturepad.app
 
 import android.util.Log
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -39,6 +48,8 @@ fun ComposeSample() {
     ) {
         var signaturePadAdapter: SignaturePadAdapter? = null
         var penColor by remember { mutableStateOf(Color.Black) }
+        var imageBackgroundColor by remember { mutableStateOf<Color?>(null) }
+        var overrideStrokeColor by remember { mutableStateOf<Color?>(null) }
 
         Box(
             modifier = Modifier
@@ -69,26 +80,10 @@ fun ComposeSample() {
                 },
             )
         }
+        Spacer(modifier = Modifier.height(8.dp))
         Column {
+            Text("Pen color:")
             Row {
-                Button(onClick = {
-                    mutableSvg.value = signaturePadAdapter?.getSignatureSvg().orEmpty()
-                    val signatureBitmap = signaturePadAdapter?.getSignatureBitmap(
-                        backgroundColor = Color.Green.toArgb(),
-                        overrideStrokeColor = Color.Blue.toArgb()
-                    )
-                    savedBitmap.value = signatureBitmap?.asImageBitmap()
-                }) {
-                    Text("Save")
-                }
-
-                Button(onClick = {
-                    mutableSvg.value = ""
-                    signaturePadAdapter?.clear()
-                }) {
-                    Text("Clear")
-                }
-
                 Button(onClick = {
                     penColor = Color.Red
                 }) {
@@ -99,11 +94,74 @@ fun ComposeSample() {
                 }) {
                     Text("Black")
                 }
+                Button(onClick = {
+                    penColor = Color.White
+                }) {
+                    Text("White")
+                }
             }
-            Button(onClick = {
-                penColor = Color.White
-            }) {
-                Text("White")
+            Spacer(modifier = Modifier.height(8.dp))
+            Text("Signature image background color:")
+            Row {
+                Button(onClick = {
+                    imageBackgroundColor = Color.Red
+                }) {
+                    Text("Red")
+                }
+                Button(onClick = {
+                    imageBackgroundColor = Color.Green
+                }) {
+                    Text("Green")
+                }
+                Button(onClick = {
+                    imageBackgroundColor = Color.Blue
+                }) {
+                    Text("Blue")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text("Signature image pen color:")
+            Row {
+                Button(onClick = {
+                    overrideStrokeColor = Color.Red
+                }) {
+                    Text("Red")
+                }
+                Button(onClick = {
+                    overrideStrokeColor = Color.Black
+                }) {
+                    Text("Black")
+                }
+                Button(onClick = {
+                    overrideStrokeColor = Color.White
+                }) {
+                    Text("White")
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            Row {
+                Button(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(end = 16.dp),
+                    onClick = {
+                    mutableSvg.value = signaturePadAdapter?.getSignatureSvg().orEmpty()
+                    val signatureBitmap = signaturePadAdapter?.getSignatureBitmap(
+                        backgroundColor = imageBackgroundColor?.toArgb() ?: Color.White.toArgb(),
+                        overrideStrokeColor = overrideStrokeColor?.toArgb()
+                    )
+                    savedBitmap.value = signatureBitmap?.asImageBitmap()
+                }) {
+                    Text("Save")
+                }
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                    mutableSvg.value = ""
+                    signaturePadAdapter?.clear()
+                }) {
+                    Text("Clear")
+                }
             }
             savedBitmap.value?.let { img ->
                 Image(
@@ -115,7 +173,11 @@ fun ComposeSample() {
                         .border(width = 1.dp, color = Color.Gray)
                 )
             }
-            Text(text = "SVG: " + mutableSvg.value)
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState())
+            ) {
+                Text(text = "SVG: " + mutableSvg.value)
+            }
         }
     }
 }

--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -22,12 +22,14 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
@@ -53,7 +55,6 @@ private fun ColorToggleGroup(
         Row(Modifier.fillMaxWidth()) {
             options.forEachIndexed { index, (label, color) ->
                 val isSelected = color == selected
-                // round only the outer corners:
                 val shape = when (index) {
                     0 -> RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
                     options.lastIndex -> RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
@@ -99,6 +100,9 @@ fun ComposeSample() {
     var penColor by remember { mutableStateOf(Color.Black) }
     var bgColor by remember { mutableStateOf(Color.White) }
     var strokeOverride by remember { mutableStateOf<Color?>(null) }
+
+    // Toggle to choose between default bitmap vs. override-color bitmap
+    var useOverride by remember { mutableStateOf(false) }
 
     Column(
         Modifier
@@ -149,6 +153,19 @@ fun ComposeSample() {
             onSelect = { strokeOverride = it }
         )
 
+        Spacer(Modifier.height(8.dp))
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 8.dp)
+        ) {
+            Text("Use override colors", Modifier.weight(1f))
+            Switch(
+                checked = useOverride,
+                onCheckedChange = { useOverride = it }
+            )
+        }
+
         Spacer(Modifier.height(16.dp))
 
         Row(
@@ -159,12 +176,19 @@ fun ComposeSample() {
                 modifier = Modifier.weight(1f),
                 onClick = {
                     svg = adapter?.getSignatureSvg().orEmpty()
-                    savedBitmap = adapter
-                        ?.getSignatureBitmap(
-                            backgroundColor = bgColor.toArgb(),
-                            overrideStrokeColor = strokeOverride?.toArgb()
-                        )
-                        ?.asImageBitmap()
+
+                    savedBitmap = if (useOverride) {
+                        adapter
+                            ?.getSignatureBitmap(
+                                backgroundColor = bgColor.toArgb(),
+                                overrideStrokeColor = strokeOverride?.toArgb()
+                            )
+                            ?.asImageBitmap()
+                    } else {
+                        adapter
+                            ?.getSignatureBitmap()
+                            ?.asImageBitmap()
+                    }
                 }
             ) {
                 Text("Save")

--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -1,6 +1,7 @@
 package se.warting.signaturepad.app
 
 import android.util.Log
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,6 +18,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import se.warting.signaturepad.SignaturePadAdapter
@@ -29,6 +33,7 @@ private const val SIGNATURE_PAD_HEIGHT = 120
 fun ComposeSample() {
 
     val mutableSvg = remember { mutableStateOf("") }
+    val savedBitmap = remember { mutableStateOf<ImageBitmap?>(null) }
     Column(
         modifier = Modifier
     ) {
@@ -67,7 +72,12 @@ fun ComposeSample() {
         Column {
             Row {
                 Button(onClick = {
-                    mutableSvg.value = signaturePadAdapter?.getSignatureSvg() ?: ""
+                    mutableSvg.value = signaturePadAdapter?.getSignatureSvg().orEmpty()
+                    val signatureBitmap = signaturePadAdapter?.getSignatureBitmap(
+                        backgroundColor = Color.Green.toArgb(),
+                        overrideStrokeColor = Color.Blue.toArgb()
+                    )
+                    savedBitmap.value = signatureBitmap?.asImageBitmap()
                 }) {
                     Text("Save")
                 }
@@ -94,6 +104,16 @@ fun ComposeSample() {
                 penColor = Color.White
             }) {
                 Text("White")
+            }
+            savedBitmap.value?.let { img ->
+                Image(
+                    bitmap = img,
+                    contentDescription = "Saved signature",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(SIGNATURE_PAD_HEIGHT.dp)
+                        .border(width = 1.dp, color = Color.Gray)
+                )
             }
             Text(text = "SVG: " + mutableSvg.value)
         }

--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -1,24 +1,27 @@
 package se.warting.signaturepad.app
 
 import android.util.Log
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
@@ -35,158 +39,169 @@ import androidx.compose.ui.unit.dp
 import se.warting.signaturepad.SignaturePadAdapter
 import se.warting.signaturepad.SignaturePadView
 
-private const val SIGNATURE_PAD_HEIGHT = 120
+private const val SIGNATURE_PAD_HEIGHT_DP = 120
 
-@Suppress("LongMethod")
 @Composable
-fun ComposeSample() {
-
-    val mutableSvg = remember { mutableStateOf("") }
-    val savedBitmap = remember { mutableStateOf<ImageBitmap?>(null) }
-    Column(
-        modifier = Modifier
-    ) {
-        var signaturePadAdapter: SignaturePadAdapter? = null
-        var penColor by remember { mutableStateOf(Color.Black) }
-        var imageBackgroundColor by remember { mutableStateOf<Color?>(null) }
-        var overrideStrokeColor by remember { mutableStateOf<Color?>(null) }
-
-        Box(
-            modifier = Modifier
-                .height(SIGNATURE_PAD_HEIGHT.dp)
-                .fillMaxWidth()
-                .border(width = 2.dp, color = Color.Red)
-        ) {
-            SignaturePadView(
-                onReady = {
-                    signaturePadAdapter = it
-                },
-                penColor = penColor,
-
-                onStartSigning = {
-                    Log.d("SignedListener", "OnStartSigning")
-                },
-                onSigning = {
-                    Log.d("SignedListener", "onSigning")
-                },
-                onSigned = {
-                    Log.d("SignedListener", "onSigned")
-                },
-                onClear = {
-                    Log.d(
-                        "ComposeFragment", "onClear isEmpty:"
-                                + signaturePadAdapter?.isEmpty
+private fun ColorToggleGroup(
+    title: String,
+    options: List<Pair<String, Color>>,
+    selected: Color,
+    onSelect: (Color) -> Unit
+) {
+    Column {
+        Text(title, style = MaterialTheme.typography.bodyMedium)
+        Row(Modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, (label, color) ->
+                val isSelected = color == selected
+                // round only the outer corners:
+                val shape = when (index) {
+                    0 -> RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
+                    options.lastIndex -> RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
+                    else -> RectangleShape
+                }
+                OutlinedButton(
+                    onClick = { onSelect(color) },
+                    shape = shape,
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        containerColor = if (isSelected)
+                            MaterialTheme.colorScheme.primaryContainer
+                        else
+                            MaterialTheme.colorScheme.surface,
+                        contentColor = if (isSelected)
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        else
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                    ),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(label)
+                }
+                if (index < options.lastIndex) {
+                    Spacer(
+                        modifier = Modifier
+                            .width(1.dp)
+                            .fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.outline)
                     )
-                },
-            )
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-        Column {
-            Text("Pen color:")
-            Row {
-                Button(onClick = {
-                    penColor = Color.Red
-                }) {
-                    Text("Red")
                 }
-                Button(onClick = {
-                    penColor = Color.Black
-                }) {
-                    Text("Black")
-                }
-                Button(onClick = {
-                    penColor = Color.White
-                }) {
-                    Text("White")
-                }
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            Text("Signature image background color:")
-            Row {
-                Button(onClick = {
-                    imageBackgroundColor = Color.Red
-                }) {
-                    Text("Red")
-                }
-                Button(onClick = {
-                    imageBackgroundColor = Color.Green
-                }) {
-                    Text("Green")
-                }
-                Button(onClick = {
-                    imageBackgroundColor = Color.Blue
-                }) {
-                    Text("Blue")
-                }
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            Text("Signature image pen color:")
-            Row {
-                Button(onClick = {
-                    overrideStrokeColor = Color.Red
-                }) {
-                    Text("Red")
-                }
-                Button(onClick = {
-                    overrideStrokeColor = Color.Black
-                }) {
-                    Text("Black")
-                }
-                Button(onClick = {
-                    overrideStrokeColor = Color.White
-                }) {
-                    Text("White")
-                }
-            }
-            Spacer(modifier = Modifier.height(24.dp))
-            Row {
-                Button(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(end = 16.dp),
-                    onClick = {
-                    mutableSvg.value = signaturePadAdapter?.getSignatureSvg().orEmpty()
-                    val signatureBitmap = signaturePadAdapter?.getSignatureBitmap(
-                        backgroundColor = imageBackgroundColor?.toArgb() ?: Color.White.toArgb(),
-                        overrideStrokeColor = overrideStrokeColor?.toArgb()
-                    )
-                    savedBitmap.value = signatureBitmap?.asImageBitmap()
-                }) {
-                    Text("Save")
-                }
-                Button(
-                    modifier = Modifier.weight(1f),
-                    onClick = {
-                    mutableSvg.value = ""
-                    signaturePadAdapter?.clear()
-                }) {
-                    Text("Clear")
-                }
-            }
-            savedBitmap.value?.let { img ->
-                Image(
-                    bitmap = img,
-                    contentDescription = "Saved signature",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(SIGNATURE_PAD_HEIGHT.dp)
-                        .border(width = 1.dp, color = Color.Gray)
-                )
-            }
-            Column(
-                modifier = Modifier.verticalScroll(rememberScrollState())
-            ) {
-                Text(text = "SVG: " + mutableSvg.value)
             }
         }
     }
 }
 
+@Composable
+fun ComposeSample() {
+    var svg by remember { mutableStateOf("") }
+    var savedBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+    var adapter by remember { mutableStateOf<SignaturePadAdapter?>(null) }
+
+    var penColor by remember { mutableStateOf(Color.Black) }
+    var bgColor by remember { mutableStateOf(Color.White) }
+    var strokeOverride by remember { mutableStateOf<Color?>(null) }
+
+    Column(
+        Modifier
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState())
+            .fillMaxWidth()
+    ) {
+        Box(
+            Modifier
+                .height(SIGNATURE_PAD_HEIGHT_DP.dp)
+                .fillMaxWidth()
+                .border(2.dp, Color.Red)
+        ) {
+            SignaturePadView(
+                onReady = { adapter = it },
+                penColor = penColor,
+                onStartSigning = { Log.d("SignedListener", "onStartSigning") },
+                onSigning = { Log.d("SignedListener", "onSigning") },
+                onSigned = { Log.d("SignedListener", "onSigned") },
+                onClear = { Log.d("ComposeSample", "isEmpty=${adapter?.isEmpty}") }
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        ColorToggleGroup(
+            title = "Pen color:",
+            options = listOf("Red" to Color.Red, "Black" to Color.Black, "White" to Color.White),
+            selected = penColor,
+            onSelect = { penColor = it }
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        ColorToggleGroup(
+            title = "Image background color:",
+            options = listOf("Red" to Color.Red, "Green" to Color.Green, "Blue" to Color.Blue),
+            selected = bgColor,
+            onSelect = { bgColor = it }
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        ColorToggleGroup(
+            title = "Image pen color:",
+            options = listOf("Red" to Color.Red, "Black" to Color.Black, "White" to Color.White),
+            selected = strokeOverride ?: Color.Black,
+            onSelect = { strokeOverride = it }
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(
+                modifier = Modifier.weight(1f),
+                onClick = {
+                    svg = adapter?.getSignatureSvg().orEmpty()
+                    savedBitmap = adapter
+                        ?.getSignatureBitmap(
+                            backgroundColor = bgColor.toArgb(),
+                            overrideStrokeColor = strokeOverride?.toArgb()
+                        )
+                        ?.asImageBitmap()
+                }
+            ) {
+                Text("Save")
+            }
+            Button(
+                modifier = Modifier.weight(1f),
+                onClick = {
+                    svg = ""
+                    adapter?.clear()
+                }
+            ) {
+                Text("Clear")
+            }
+        }
+
+        savedBitmap?.let { img ->
+            Spacer(Modifier.height(12.dp))
+            Image(
+                bitmap = img,
+                contentDescription = "Saved signature",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(SIGNATURE_PAD_HEIGHT_DP.dp)
+                    .border(1.dp, Color.Gray)
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+        Text("SVG:", style = MaterialTheme.typography.bodyMedium)
+        Text(svg, style = MaterialTheme.typography.bodySmall)
+    }
+}
 
 @Preview(showBackground = true)
 @Composable
-fun DefaultPreview() {
+fun ComposeSamplePreview() {
     MaterialTheme {
-        SignaturePadView()
+        ComposeSample()
     }
 }

--- a/app/src/main/java/se/warting/signaturepad/app/MainActivity.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/MainActivity.kt
@@ -4,16 +4,28 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -25,22 +37,10 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.compose.AndroidFragment
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DarkMode
-import androidx.compose.material.icons.filled.LightMode
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.runtime.SideEffect
-import androidx.compose.material3.Icon
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.ui.tooling.preview.UiMode
+import se.warting.signaturepad.app.ComposeSample
+import se.warting.signaturepad.app.DataBindingSampleFragment
+import se.warting.signaturepad.app.SaveRestoreSample
+import se.warting.signaturepad.app.ViewFragment
 
 @OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : FragmentActivity() {

--- a/app/src/main/java/se/warting/signaturepad/app/MainActivity.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.compose.AndroidFragment
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
+import androidx.compose.ui.graphics.Color
 
 @OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : FragmentActivity() {

--- a/app/src/main/java/se/warting/signaturepad/app/MainActivity.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/MainActivity.kt
@@ -37,10 +37,6 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.compose.AndroidFragment
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
-import se.warting.signaturepad.app.ComposeSample
-import se.warting.signaturepad.app.DataBindingSampleFragment
-import se.warting.signaturepad.app.SaveRestoreSample
-import se.warting.signaturepad.app.ViewFragment
 
 @OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : FragmentActivity() {

--- a/app/src/main/java/se/warting/signaturepad/app/MainActivity.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/MainActivity.kt
@@ -3,6 +3,8 @@ package se.warting.signaturepad.app
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -12,25 +14,100 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.compose.AndroidFragment
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.runtime.SideEffect
+import androidx.compose.material3.Icon
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.tooling.preview.UiMode
 
+@OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
-            MaterialTheme {
-                Scaffold { padding ->
 
-                    Navigation(modifier = Modifier
+            var uiMode by rememberSaveable { mutableStateOf(AppUiMode.SYSTEM) }
+
+            val darkTheme = when (uiMode) {
+                AppUiMode.DARK -> true
+                AppUiMode.LIGHT -> false
+                AppUiMode.SYSTEM -> isSystemInDarkTheme()
+            }
+
+            SideEffect {
+                AppCompatDelegate.setDefaultNightMode(
+                    when (uiMode) {
+                        AppUiMode.DARK -> AppCompatDelegate.MODE_NIGHT_YES
+                        AppUiMode.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+                        AppUiMode.SYSTEM -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                    }
+                )
+            }
+
+            val colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()
+
+            MaterialTheme(colorScheme = colorScheme) {
+
+                var menuExpanded by rememberSaveable { mutableStateOf(false) }
+
+                Scaffold(
+                    topBar = {
+                        TopAppBar(
+                            title = { Text(text = "SignaturePad Samples") },
+                            actions = {
+                                IconButton(onClick = { menuExpanded = true }) {
+                                    Icon(Icons.Filled.MoreVert, contentDescription = "Theme menu")
+                                }
+
+                                DropdownMenu(
+                                    expanded = menuExpanded,
+                                    onDismissRequest = { menuExpanded = false }
+                                ) {
+                                    DropdownMenuItem(text = { Text("Follow system") }, onClick = {
+                                        uiMode = AppUiMode.SYSTEM
+                                        menuExpanded = false
+                                    })
+                                    DropdownMenuItem(text = { Text("Light") }, onClick = {
+                                        uiMode = AppUiMode.LIGHT
+                                        menuExpanded = false
+                                    })
+                                    DropdownMenuItem(text = { Text("Dark") }, onClick = {
+                                        uiMode = AppUiMode.DARK
+                                        menuExpanded = false
+                                    })
+                                }
+                            }
+                        )
+                    }
+                ) { padding ->
+                    Box(modifier = Modifier
                         .padding(padding)
-                        .safeContentPadding())
+                        .safeContentPadding()) {
+                        Navigation()
+                    }
                 }
             }
         }
@@ -130,3 +207,5 @@ fun Home(
         }
     }
 }
+
+enum class AppUiMode { LIGHT, DARK, SYSTEM }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+agp = "8.9.2"
 io-gitlab-arturbosch-detekt = "1.23.8"
 kotlin = "2.1.21"
 composeBom = "2025.06.00"
@@ -20,7 +21,7 @@ androidx-core-core-ktx = "androidx.core:core-ktx:1.16.0"
 androidx-lifecycle-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.9.1"
 androidx-test-espresso-espresso-core = "androidx.test.espresso:espresso-core:3.6.1"
 androidx-test-ext-junit = "androidx.test.ext:junit:1.2.1"
-com-android-tools-build-gradle = "com.android.tools.build:gradle:8.10.1"
+com-android-tools-build-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 com-google-android-material = "com.google.android.material:material:1.12.0"
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 io-gitlab-arturbosch-detekt-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "io-gitlab-arturbosch-detekt" }
@@ -32,8 +33,8 @@ androidx-navigation3-ui-android = { group = "androidx.navigation3", name = "navi
 androidx-fragment-fragment-compose = "androidx.fragment:fragment-compose:1.8.8"
 
 [plugins]
-com-android-application = "com.android.application:8.10.1"
-com-android-library = "com.android.library:8.10.1"
+com-android-application = { id = "com.android.application", version.ref = "agp" }
+com-android-library = { id = "com.android.library", version.ref = "agp" }
 com-gladed-androidgitversion = "com.gladed.androidgitversion:0.4.14"
 com-vanniktech-maven-publish = "com.vanniktech.maven.publish:0.32.0"
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -236,8 +236,8 @@ class SignatureSDK {
     /**
      * Returns a bitmap containing the current signature.
      *
-     * @param backgroundColor Color placed behind the signature. Defaults to white for backward compatibility.
-     * @param penColor If provided, the stroke is recoloured to this value before returning.
+     * @param backgroundColor Color placed behind the signature
+     * @param penColor Color of the signature itself
      */
     fun getSignatureBitmap(
         backgroundColor: Int = Color.WHITE,
@@ -264,23 +264,18 @@ class SignatureSDK {
         trimBlankSpace: Boolean = false,
         penColor: Int? = null,
     ): Bitmap? {
-        // Ensure we have a source bitmap to start from
-        val sourceBitmap = signatureTransparentBitmap ?: return null
+        val originalTransparentBitmap = signatureTransparentBitmap ?: return null
 
-        // 1. Apply an optional stroke colour override on a copy of the source bitmap.
-        //    We do this first so the recoloured image is also considered when trimming.
         val processedBitmap: Bitmap = penColor?.let { color ->
-            // Create a new bitmap with a transparent background and draw the original
-            // bitmap onto it using a colour filter to override the stroke colour.
-            val recoloured = createBitmap(sourceBitmap.width, sourceBitmap.height)
+            val recoloured = createBitmap(originalTransparentBitmap.width, originalTransparentBitmap.height)
             val canvas = Canvas(recoloured)
             val paint = Paint().apply {
                 colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN)
                 isAntiAlias = true
             }
-            canvas.drawBitmap(sourceBitmap, 0f, 0f, paint)
+            canvas.drawBitmap(originalTransparentBitmap, 0f, 0f, paint)
             recoloured
-        } ?: sourceBitmap
+        } ?: originalTransparentBitmap
 
         if (!trimBlankSpace) {
             return processedBitmap

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -247,13 +247,7 @@ class SignatureSDK {
             val bitmapToReturn = createBitmap(originalBitmap.width, originalBitmap.height)
             val canvas = Canvas(bitmapToReturn)
             canvas.drawColor(backgroundColor)
-            val paint: Paint? = penColor?.let { color ->
-                Paint().apply {
-                    colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN)
-                    isAntiAlias = true
-                }
-            }
-            canvas.drawBitmap(originalBitmap, 0f, 0f, paint)
+            canvas.drawBitmap(originalBitmap, 0f, 0f, penColor?.adjustPaint())
             return bitmapToReturn
         }
         return null
@@ -275,11 +269,7 @@ class SignatureSDK {
         val processedBitmap: Bitmap = penColor?.let { color ->
             val recoloured = createBitmap(originalTransparentBitmap.width, originalTransparentBitmap.height)
             val canvas = Canvas(recoloured)
-            val paint = Paint().apply {
-                colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN)
-                isAntiAlias = true
-            }
-            canvas.drawBitmap(originalTransparentBitmap, 0f, 0f, paint)
+            canvas.drawBitmap(originalTransparentBitmap, 0f, 0f, color.adjustPaint())
             recoloured
         } ?: originalTransparentBitmap
 
@@ -485,5 +475,10 @@ class SignatureSDK {
 
     private fun strokeWidth(velocity: Float): Float {
         return max(maxWidth / (velocity + 1), minWidth.toFloat())
+    }
+
+    private fun Int.adjustPaint(): Paint = Paint().apply {
+        colorFilter = PorterDuffColorFilter(this@adjustPaint, PorterDuff.Mode.SRC_IN)
+        isAntiAlias = true
     }
 }

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -17,6 +17,8 @@ import se.warting.signaturecore.utils.TimedPoint
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.sqrt
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 
 class SignatureSDK {
 
@@ -231,13 +233,28 @@ class SignatureSDK {
         }
     }
 
-    fun getSignatureBitmap(): Bitmap? {
+    /**
+     * Returns a bitmap containing the current signature.
+     *
+     * @param backgroundColor Color placed behind the signature. Defaults to white for backward compatibility.
+     * @param overrideStrokeColor If provided, the stroke is recoloured to this value before returning.
+     */
+    fun getSignatureBitmap(
+        backgroundColor: Int = Color.WHITE,
+        overrideStrokeColor: Int? = null,
+    ): Bitmap? {
         signatureTransparentBitmap?.let { originalBitmap ->
-            val whiteBgBitmap = createBitmap(originalBitmap.width, originalBitmap.height)
-            val canvas = Canvas(whiteBgBitmap)
-            canvas.drawColor(Color.WHITE)
-            canvas.drawBitmap(originalBitmap, 0f, 0f, null)
-            return whiteBgBitmap
+            val bitmapToReturn = createBitmap(originalBitmap.width, originalBitmap.height)
+            val canvas = Canvas(bitmapToReturn)
+            canvas.drawColor(backgroundColor)
+            val paint: Paint? = overrideStrokeColor?.let { color ->
+                Paint().apply {
+                    colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN)
+                    isAntiAlias = true
+                }
+            }
+            canvas.drawBitmap(originalBitmap, 0f, 0f, paint)
+            return bitmapToReturn
         }
         return null
     }

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -274,7 +274,7 @@ class SignatureSDK {
         } ?: originalTransparentBitmap
 
         if (!trimBlankSpace) {
-            return processedBitmap
+            return processedBitmap.copy(Bitmap.Config.ARGB_8888, false)
         }
 
         val bitmap = processedBitmap

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -259,6 +259,12 @@ class SignatureSDK {
         return null
     }
 
+    /**
+     * Returns a bitmap containing the current signature.
+     *
+     * @param trimBlankSpace If true, bitmap is cropped to the signature bounds and surrounding blank space is removed
+     * @param penColor Color of the signature line in the bitmap
+     */
     @Suppress("LongMethod", "CyclomaticComplexMethod", "ReturnCount")
     fun getTransparentSignatureBitmap(
         trimBlankSpace: Boolean = false,

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -78,13 +78,13 @@ class SignaturePadAdapter(private val signaturePad: SignaturePad) {
         return signaturePad.getSignatureBitmap()
     }
 
-    fun getSignatureBitmap(backgroundColor: Int, overrideStrokeColor: Int? = null): Bitmap {
-        return signaturePad.getSignatureBitmap(backgroundColor, overrideStrokeColor)
+    fun getSignatureBitmap(backgroundColor: Int, penColor: Int? = null): Bitmap {
+        return signaturePad.getSignatureBitmap(backgroundColor, penColor)
     }
 
     @Suppress("unused")
-    fun getTransparentSignatureBitmap(trimBlankSpace: Boolean = false): Bitmap {
-        return signaturePad.getTransparentSignatureBitmap(trimBlankSpace)
+    fun getTransparentSignatureBitmap(trimBlankSpace: Boolean = false, penColor: Int? = null): Bitmap {
+        return signaturePad.getTransparentSignatureBitmap(trimBlankSpace, penColor)
     }
 
     fun getSignatureSvg(): String {

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -78,6 +78,12 @@ class SignaturePadAdapter(private val signaturePad: SignaturePad) {
         return signaturePad.getSignatureBitmap()
     }
 
+    /**
+     * Returns a bitmap containing the current signature.
+     *
+     * @param backgroundColor Color of the bitmap's surface behind the signature
+     * @param penColor Color of the signature line in the bitmap
+     */
     fun getSignatureBitmap(backgroundColor: Int, penColor: Int? = null): Bitmap {
         return signaturePad.getSignatureBitmap(backgroundColor, penColor)
     }

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -78,6 +78,10 @@ class SignaturePadAdapter(private val signaturePad: SignaturePad) {
         return signaturePad.getSignatureBitmap()
     }
 
+    fun getSignatureBitmap(backgroundColor: Int, overrideStrokeColor: Int? = null): Bitmap {
+        return signaturePad.getSignatureBitmap(backgroundColor, overrideStrokeColor)
+    }
+
     @Suppress("unused")
     fun getTransparentSignatureBitmap(trimBlankSpace: Boolean = false): Bitmap {
         return signaturePad.getTransparentSignatureBitmap(trimBlankSpace)

--- a/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
@@ -224,14 +224,17 @@ class SignaturePad(context: Context, attrs: AttributeSet?) : View(context, attrs
 
     fun getSignatureBitmap(
         backgroundColor: Int,
-        overrideStrokeColor: Int? = null,
+        penColor: Int? = null,
     ): Bitmap {
-        return signatureSDK.getSignatureBitmap(backgroundColor, overrideStrokeColor)
+        return signatureSDK.getSignatureBitmap(backgroundColor, penColor)
             ?: createBitmap(1, 1)
     }
 
-    fun getTransparentSignatureBitmap(trimBlankSpace: Boolean = false): Bitmap {
-        return signatureSDK.getTransparentSignatureBitmap(trimBlankSpace)
+    fun getTransparentSignatureBitmap(
+        trimBlankSpace: Boolean = false,
+        penColor: Int? = null,
+    ): Bitmap {
+        return signatureSDK.getTransparentSignatureBitmap(trimBlankSpace, penColor)
             ?: createBitmap(1, 1)
     }
 

--- a/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
@@ -222,6 +222,14 @@ class SignaturePad(context: Context, attrs: AttributeSet?) : View(context, attrs
         return signatureSDK.getSignatureBitmap() ?: createBitmap(1, 1)
     }
 
+    fun getSignatureBitmap(
+        backgroundColor: Int,
+        overrideStrokeColor: Int? = null,
+    ): Bitmap {
+        return signatureSDK.getSignatureBitmap(backgroundColor, overrideStrokeColor)
+            ?: createBitmap(1, 1)
+    }
+
     fun getTransparentSignatureBitmap(trimBlankSpace: Boolean = false): Bitmap {
         return signatureSDK.getTransparentSignatureBitmap(trimBlankSpace)
             ?: createBitmap(1, 1)


### PR DESCRIPTION
Resolves https://github.com/warting/android-signaturepad/issues/331

## This PR...

1. Adds more flexibility for bitmap pen and background coloring. 
2. Improves the Compose section of the test app with:
  - UI to play around with various image pen and background coloring
  - day/night UI toggling
3. Drops Android Gradle Plugin version to `8.9.2` to fix a build issue. I was experiencing this in Android Studio when trying to build the test app on `main` **and** it seems to be a problem in recent Github Actions builds.

@warting , the changes in the test app's Compose screen are quite opinionated. If you don't like them, go ahead and adjust however you want. However, the new coloring preferences in the actual code **are** working and are the key part of this pr, so I'd ask that you focus on this new functionality and focus less on the test app UI ✨  😬 

## Considerations and implementation

_What technical details should the team pay particular attention to? What unexpected issues did you encounter?_

### How to test

Play around with the Compose section of the test app

### Test(s) added 



### Screenshots


https://github.com/user-attachments/assets/5d9d09dd-fa2a-4e7f-b5ee-c9b4839ac7fe


https://github.com/user-attachments/assets/809dd182-b936-44c7-b9a5-4adc619e0d4a


Realistically, many folks like myself might be passing `MaterialTheme.colorScheme.surface` through as the image background color so that displaying the image's Bitmap just looks like the signature itself👇🏽 


<img width="382" alt="Screenshot 2025-06-18 at 10 09 17 AM" src="https://github.com/user-attachments/assets/e1907440-aca0-4b0b-ae97-e77aa3f9bda0" />

without border

<img width="454" alt="Screenshot 2025-06-24 at 9 27 09 AM" src="https://github.com/user-attachments/assets/3839b3c6-66f1-4f99-819a-37e7b19e32b7" />
