### PR TITLE
Fix release-drafter failing on every PR

### DIFF
--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: release-drafter/release-drafter@v7.1.1
         with:
           config-name: release-drafter.yml
-          disable-autolabeler: false
+          # On pull_request, GITHUB_REF is refs/pull/N/merge, which GitHub's
+          # release API rejects as target_commitish. Skip the release update on
+          # PRs (autolabeler still runs); the draft is updated on push to main.
+          dry-run: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- release-drafter v7.x rejects `pull_request` runs because `GITHUB_REF` is `refs/pull/N/merge`, which GitHub's REST API does not accept as `target_commitish`. Every PR since the v7.0 bump (#466) has failed with `Validation Failed: target_commitish invalid` (see e.g. [#469's run](https://github.com/warting/android-signaturepad/actions/runs/23630575298), [#474's run](https://github.com/warting/android-signaturepad/actions/runs/25133613325)).
- Set `dry-run: true` on `pull_request` events so the autolabeler still runs but the release-update API call is skipped. On `push` to `main` the draft release is still updated as before.
- Also drop the now-invalid `disable-autolabeler` input — it was removed in v7 and the action emits a warning about it on every run.

## Test plan
- [ ] CI passes the `update_draft_release` job on this PR
- [ ] After merge, push to main still updates the draft release
- [ ] Autolabeler still applies labels to PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)