### PR TITLE
Support pen and background color in getSignatureSvg()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ signature-pad (Compose) ──api──> signature-core
 
 - **Gradle** with Kotlin DSL (`.gradle.kts` files)
 - **Version catalog**: `gradle/libs.versions.toml` for all dependency versions
-- **JDK 17** required (configured via `jvmToolchain(17)`)
+- **JDK 21** required (configured via `jvmToolchain(21)`, auto-provisioned via the `foojay-resolver-convention` plugin in `settings.gradle.kts`)
 - **compileSdk 36**, **minSdk 21**
 - **Kotlin 2.2.x** with Compose compiler plugin
 - **AGP** (Android Gradle Plugin) 8.13.x

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ android {
         disable.add("LogConditional")
         disable.add("AndroidGradlePluginVersion")
         disable.add("NewerVersionAvailable")
+        disable.add("OldTargetApi")
         checkDependencies = true
         checkGeneratedSources = false
         sarifOutput = file("../lint-results-lib.sarif")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,7 +37,7 @@ android {
         }
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
         freeCompilerArgs = listOfNotNull(
             "-opt-in=kotlin.RequiresOptIn",
             "-Xskip-prerelease-check"
@@ -71,7 +71,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 7.4.0-beta04" type="baseline" client="gradle" dependencies="true" name="AGP (7.4.0-beta04)" variant="all" version="7.4.0-beta04">
+<issues format="6" by="lint 8.13.1" type="baseline" client="gradle" dependencies="true" name="AGP (8.13.1)" variant="all" version="8.13.1">
+
+    <issue
+        id="Instantiatable"
+        message="`MainActivity` must extend android.app.Activity"
+        errorLine1="            android:name=&quot;.MainActivity&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="12"
+            column="27"/>
+    </issue>
 
     <issue
         id="MonochromeLauncherIcon"
@@ -21,17 +32,6 @@
             file="src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml"
             line="2"
             column="1"/>
-    </issue>
-
-    <issue
-        id="KtxExtensionAvailable"
-        message="Add suffix `-ktx` to enable the Kotlin extensions for this library"
-        errorLine1="    implementation(&quot;androidx.core:core:1.9.0&quot;)"
-        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle.kts"
-            line="83"
-            column="21"/>
     </issue>
 
 </issues>

--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -192,7 +192,16 @@ fun ComposeSample() {
 
         SaveClearRow(
             onSave = {
-                svg = adapter?.getSignatureSvg().orEmpty()
+                svg = adapter?.let { a ->
+                    if (useOverride) {
+                        a.getSignatureSvg(
+                            penColor = toggles[2].state.value.toArgb(),
+                            backgroundColor = toggles[1].state.value.toArgb(),
+                        )
+                    } else {
+                        a.getSignatureSvg()
+                    }
+                }.orEmpty()
                 adapter?.let {
                     bmpPair = it.extractBitmaps(
                         useOverride = useOverride,

--- a/signature-core/api/signature-core.api
+++ b/signature-core/api/signature-core.api
@@ -73,6 +73,8 @@ public final class se/warting/signaturecore/SignatureSDK {
 	public final fun getSignatureBitmap (ILjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getSignatureBitmap$default (Lse/warting/signaturecore/SignatureSDK;ILjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun getSignatureSvg (II)Ljava/lang/String;
+	public final fun getSignatureSvg (IILjava/lang/Integer;Ljava/lang/Integer;)Ljava/lang/String;
+	public static synthetic fun getSignatureSvg$default (Lse/warting/signaturecore/SignatureSDK;IILjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Ljava/lang/String;
 	public final fun getTransparentSignatureBitmap (ZLjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getTransparentSignatureBitmap$default (Lse/warting/signaturecore/SignatureSDK;ZLjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun hasBitmap ()Z
@@ -139,6 +141,7 @@ public final class se/warting/signaturecore/utils/SvgBuilder {
 	public fun <init> ()V
 	public final fun append (Lse/warting/signaturecore/utils/Bezier;F)Lse/warting/signaturecore/utils/SvgBuilder;
 	public final fun build (II)Ljava/lang/String;
+	public final fun build (IILjava/lang/Integer;Ljava/lang/Integer;)Ljava/lang/String;
 	public final fun clear ()V
 }
 

--- a/signature-core/build.gradle.kts
+++ b/signature-core/build.gradle.kts
@@ -78,7 +78,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
         freeCompilerArgs = listOfNotNull(
             "-opt-in=kotlin.RequiresOptIn",
             "-Xskip-prerelease-check"
@@ -102,7 +102,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {
@@ -111,5 +111,6 @@ dependencies {
     androidTestImplementation(composeBom)
     implementation(libs.androidx.core.core.ktx)
     implementation(libs.androidx.compose.runtime)
+    testImplementation(libs.junit)
     detektPlugins(libs.io.gitlab.arturbosch.detekt.detekt.formatting)
 }

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -217,6 +217,24 @@ class SignatureSDK {
         return svgBuilder.build(width, height)
     }
 
+    /**
+     * Returns the current signature as an SVG document.
+     *
+     * @param width Width of the SVG canvas in pixels.
+     * @param height Height of the SVG canvas in pixels.
+     * @param penColor ARGB color used for the signature stroke. If null, the stroke defaults to black.
+     * @param backgroundColor ARGB color drawn as a filled rect behind the signature. If null, the
+     *                        SVG has no background (the area is transparent).
+     */
+    fun getSignatureSvg(
+        width: Int,
+        height: Int,
+        penColor: Int?,
+        backgroundColor: Int? = null,
+    ): String {
+        return svgBuilder.build(width, height, penColor, backgroundColor)
+    }
+
     fun initializeBitmap(width: Int, height: Int) {
         if (signatureTransparentBitmap == null && width > 0 && height > 0) {
             signatureTransparentBitmap = createBitmap(width, height).also {

--- a/signature-core/src/main/java/se/warting/signaturecore/utils/SvgBuilder.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/utils/SvgBuilder.kt
@@ -18,9 +18,6 @@ class SvgBuilder {
         penColor: Int?,
         backgroundColor: Int?,
     ): String {
-        if (isPathStarted) {
-            appendCurrentPath()
-        }
         val sb = StringBuilder()
             .append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n")
             .append("<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.2\" baseProfile=\"tiny\" ")
@@ -47,7 +44,10 @@ class SvgBuilder {
         appendStroke(sb, penColor)
         sb.append(">")
             .append(mSvgPathsBuilder)
-            .append("</g>")
+        if (isPathStarted) {
+            sb.append(mCurrentPathBuilder)
+        }
+        sb.append("</g>")
             .append("</svg>")
         return sb.toString()
     }

--- a/signature-core/src/main/java/se/warting/signaturecore/utils/SvgBuilder.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/utils/SvgBuilder.kt
@@ -10,11 +10,18 @@ class SvgBuilder {
         mCurrentPathBuilder = null
     }
 
-    fun build(width: Int, height: Int): String {
+    fun build(width: Int, height: Int): String = build(width, height, null, null)
+
+    fun build(
+        width: Int,
+        height: Int,
+        penColor: Int?,
+        backgroundColor: Int?,
+    ): String {
         if (isPathStarted) {
             appendCurrentPath()
         }
-        return StringBuilder()
+        val sb = StringBuilder()
             .append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n")
             .append("<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.2\" baseProfile=\"tiny\" ")
             .append("height=\"")
@@ -32,16 +39,17 @@ class SvgBuilder {
             .append(" ")
             .append(height)
             .append("\">")
-            .append("<g ")
+        appendBackground(sb, backgroundColor)
+        sb.append("<g ")
             .append("stroke-linejoin=\"round\" ")
             .append("stroke-linecap=\"round\" ")
             .append("fill=\"none\" ")
-            .append("stroke=\"black\"")
-            .append(">")
+        appendStroke(sb, penColor)
+        sb.append(">")
             .append(mSvgPathsBuilder)
             .append("</g>")
             .append("</svg>")
-            .toString()
+        return sb.toString()
     }
 
     fun append(curve: Bezier, strokeWidth: Float): SvgBuilder {
@@ -73,4 +81,45 @@ class SvgBuilder {
 
     private val isPathStarted: Boolean
         get() = mCurrentPathBuilder != null
+
+    private fun appendBackground(sb: StringBuilder, backgroundColor: Int?) {
+        if (backgroundColor == null) return
+        sb.append("<rect width=\"100%\" height=\"100%\" fill=\"")
+            .append(toRgbHex(backgroundColor))
+            .append("\"")
+        val alpha = alphaFraction(backgroundColor)
+        if (alpha < 1f) {
+            sb.append(" fill-opacity=\"").append(formatOpacity(alpha)).append("\"")
+        }
+        sb.append("/>")
+    }
+
+    private fun appendStroke(sb: StringBuilder, penColor: Int?) {
+        if (penColor == null) {
+            sb.append("stroke=\"black\"")
+            return
+        }
+        sb.append("stroke=\"").append(toRgbHex(penColor)).append("\"")
+        val alpha = alphaFraction(penColor)
+        if (alpha < 1f) {
+            sb.append(" stroke-opacity=\"").append(formatOpacity(alpha)).append("\"")
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun toRgbHex(argb: Int): String {
+        val r = (argb shr 16) and 0xFF
+        val g = (argb shr 8) and 0xFF
+        val b = argb and 0xFF
+        return "#%02X%02X%02X".format(r, g, b)
+    }
+
+    @Suppress("MagicNumber")
+    private fun alphaFraction(argb: Int): Float = ((argb shr 24) and 0xFF) / 255f
+
+    @Suppress("MagicNumber")
+    private fun formatOpacity(alpha: Float): String {
+        val rounded = (alpha * 1000f).roundToInt() / 1000f
+        return rounded.toString().trimEnd('0').trimEnd('.').ifEmpty { "0" }
+    }
 }

--- a/signature-core/src/test/java/se/warting/signaturecore/utils/SvgBuilderTest.kt
+++ b/signature-core/src/test/java/se/warting/signaturecore/utils/SvgBuilderTest.kt
@@ -1,0 +1,83 @@
+package se.warting.signaturecore.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SvgBuilderTest {
+
+    @Test
+    fun build_withDefaults_emitsBlackStrokeAndNoBackground() {
+        val svg = SvgBuilder().build(width = 100, height = 50)
+
+        assertTrue("Expected black fallback stroke", svg.contains("stroke=\"black\""))
+        assertFalse("Expected no background rect by default", svg.contains("<rect"))
+        assertFalse("Expected no opacity attrs", svg.contains("stroke-opacity"))
+    }
+
+    @Test
+    fun build_withOpaquePenColor_emitsHexStroke() {
+        // Opaque red (ARGB 0xFFFF0000)
+        val svg = SvgBuilder().build(
+            width = 10,
+            height = 10,
+            penColor = 0xFFFF0000.toInt(),
+            backgroundColor = null,
+        )
+
+        assertTrue(svg.contains("stroke=\"#FF0000\""))
+        assertFalse("Opaque colors should not include stroke-opacity", svg.contains("stroke-opacity"))
+    }
+
+    @Test
+    fun build_withTranslucentPenColor_emitsStrokeOpacity() {
+        // 50% green (alpha 0x80)
+        val svg = SvgBuilder().build(
+            width = 10,
+            height = 10,
+            penColor = 0x8000FF00.toInt(),
+            backgroundColor = null,
+        )
+
+        assertTrue(svg.contains("stroke=\"#00FF00\""))
+        assertTrue("Translucent colors should include stroke-opacity", svg.contains("stroke-opacity=\""))
+    }
+
+    @Test
+    fun build_withBackgroundColor_emitsRectBeforePaths() {
+        val svg = SvgBuilder().build(
+            width = 20,
+            height = 20,
+            penColor = null,
+            backgroundColor = 0xFFFFFFFF.toInt(),
+        )
+
+        val rectIndex = svg.indexOf("<rect")
+        val groupIndex = svg.indexOf("<g ")
+        assertTrue("Expected <rect> before <g>", rectIndex in 0 until groupIndex)
+        assertTrue(svg.contains("fill=\"#FFFFFF\""))
+        assertTrue(svg.contains("width=\"100%\""))
+        assertTrue(svg.contains("height=\"100%\""))
+    }
+
+    @Test
+    fun build_withTranslucentBackground_emitsFillOpacity() {
+        val svg = SvgBuilder().build(
+            width = 1,
+            height = 1,
+            penColor = null,
+            backgroundColor = 0x40123456,
+        )
+
+        assertTrue(svg.contains("fill=\"#123456\""))
+        assertTrue(svg.contains("fill-opacity=\""))
+    }
+
+    @Test
+    fun build_isStableForSameInput() {
+        val first = SvgBuilder().build(50, 25, penColor = 0xFF112233.toInt(), backgroundColor = null)
+        val second = SvgBuilder().build(50, 25, penColor = 0xFF112233.toInt(), backgroundColor = null)
+        assertEquals(first, second)
+    }
+}

--- a/signature-core/src/test/java/se/warting/signaturecore/utils/SvgBuilderTest.kt
+++ b/signature-core/src/test/java/se/warting/signaturecore/utils/SvgBuilderTest.kt
@@ -80,4 +80,34 @@ class SvgBuilderTest {
         val second = SvgBuilder().build(50, 25, penColor = 0xFF112233.toInt(), backgroundColor = null)
         assertEquals(first, second)
     }
+
+    @Test
+    fun build_isIdempotentWithAppendedCurves() {
+        val builder = SvgBuilder().apply {
+            append(makeBezier(0f, 0f, 5f, 0f, 10f, 5f, 15f, 10f), strokeWidth = 4f)
+            append(makeBezier(15f, 10f, 20f, 15f, 25f, 20f, 30f, 25f), strokeWidth = 4f)
+        }
+
+        val firstSvg = builder.build(width = 50, height = 50, penColor = null, backgroundColor = null)
+        val secondSvg = builder.build(width = 50, height = 50, penColor = null, backgroundColor = null)
+
+        assertTrue("Expected at least one <path> in SVG output", firstSvg.contains("<path "))
+        assertEquals("Repeated build() must produce identical output", firstSvg, secondSvg)
+    }
+
+    private fun makeBezier(
+        sx: Float,
+        sy: Float,
+        c1x: Float,
+        c1y: Float,
+        c2x: Float,
+        c2y: Float,
+        ex: Float,
+        ey: Float,
+    ): Bezier = Bezier(
+        TimedPoint().set(sx, sy, 0L),
+        TimedPoint().set(c1x, c1y, 0L),
+        TimedPoint().set(c2x, c2y, 0L),
+        TimedPoint().set(ex, ey, 0L),
+    )
 }

--- a/signature-pad/api/signature-pad.api
+++ b/signature-pad/api/signature-pad.api
@@ -7,8 +7,8 @@ public final class se/warting/signaturepad/SignaturePadAdapter {
 	public final fun getSignatureBitmap (ILjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getSignatureBitmap$default (Lse/warting/signaturepad/SignaturePadAdapter;ILjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun getSignatureSvg ()Ljava/lang/String;
-	public final fun getSignatureSvg (ILjava/lang/Integer;)Ljava/lang/String;
-	public static synthetic fun getSignatureSvg$default (Lse/warting/signaturepad/SignaturePadAdapter;ILjava/lang/Integer;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun getSignatureSvg (Ljava/lang/Integer;Ljava/lang/Integer;)Ljava/lang/String;
+	public static synthetic fun getSignatureSvg$default (Lse/warting/signaturepad/SignaturePadAdapter;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Ljava/lang/String;
 	public final fun getTransparentSignatureBitmap (ZLjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getTransparentSignatureBitmap$default (Lse/warting/signaturepad/SignaturePadAdapter;ZLjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun isEmpty ()Z

--- a/signature-pad/api/signature-pad.api
+++ b/signature-pad/api/signature-pad.api
@@ -7,6 +7,8 @@ public final class se/warting/signaturepad/SignaturePadAdapter {
 	public final fun getSignatureBitmap (ILjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getSignatureBitmap$default (Lse/warting/signaturepad/SignaturePadAdapter;ILjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun getSignatureSvg ()Ljava/lang/String;
+	public final fun getSignatureSvg (ILjava/lang/Integer;)Ljava/lang/String;
+	public static synthetic fun getSignatureSvg$default (Lse/warting/signaturepad/SignaturePadAdapter;ILjava/lang/Integer;ILjava/lang/Object;)Ljava/lang/String;
 	public final fun getTransparentSignatureBitmap (ZLjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getTransparentSignatureBitmap$default (Lse/warting/signaturepad/SignaturePadAdapter;ZLjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun isEmpty ()Z

--- a/signature-pad/build.gradle.kts
+++ b/signature-pad/build.gradle.kts
@@ -76,7 +76,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
         freeCompilerArgs = listOfNotNull(
             "-opt-in=kotlin.RequiresOptIn",
             "-Xskip-prerelease-check"
@@ -100,7 +100,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -97,6 +97,16 @@ class SignaturePadAdapter(private val signaturePad: SignaturePad) {
         return signaturePad.getSignatureSvg()
     }
 
+    /**
+     * Returns the current signature as an SVG document with optional coloring.
+     *
+     * @param penColor ARGB color of the signature stroke.
+     * @param backgroundColor ARGB color filled behind the signature. If null the SVG is transparent.
+     */
+    fun getSignatureSvg(penColor: Int, backgroundColor: Int? = null): String {
+        return signaturePad.getSignatureSvg(penColor, backgroundColor)
+    }
+
     @ExperimentalSignatureApi
     fun getSignature(): Signature {
         return signaturePad.getSignature()

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -100,10 +100,10 @@ class SignaturePadAdapter(private val signaturePad: SignaturePad) {
     /**
      * Returns the current signature as an SVG document with optional coloring.
      *
-     * @param penColor ARGB color of the signature stroke.
+     * @param penColor ARGB color of the signature stroke. If null the stroke defaults to black.
      * @param backgroundColor ARGB color filled behind the signature. If null the SVG is transparent.
      */
-    fun getSignatureSvg(penColor: Int, backgroundColor: Int? = null): String {
+    fun getSignatureSvg(penColor: Int? = null, backgroundColor: Int? = null): String {
         return signaturePad.getSignatureSvg(penColor, backgroundColor)
     }
 

--- a/signature-view/api/signature-view.api
+++ b/signature-view/api/signature-view.api
@@ -73,6 +73,8 @@ public final class se/warting/signatureview/views/SignaturePad : android/view/Vi
 	public final fun getSignatureBitmap (ILjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getSignatureBitmap$default (Lse/warting/signatureview/views/SignaturePad;ILjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun getSignatureSvg ()Ljava/lang/String;
+	public final fun getSignatureSvg (ILjava/lang/Integer;)Ljava/lang/String;
+	public static synthetic fun getSignatureSvg$default (Lse/warting/signatureview/views/SignaturePad;ILjava/lang/Integer;ILjava/lang/Object;)Ljava/lang/String;
 	public final fun getTransparentSignatureBitmap (ZLjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getTransparentSignatureBitmap$default (Lse/warting/signatureview/views/SignaturePad;ZLjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun isEmpty ()Z

--- a/signature-view/api/signature-view.api
+++ b/signature-view/api/signature-view.api
@@ -73,8 +73,8 @@ public final class se/warting/signatureview/views/SignaturePad : android/view/Vi
 	public final fun getSignatureBitmap (ILjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getSignatureBitmap$default (Lse/warting/signatureview/views/SignaturePad;ILjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun getSignatureSvg ()Ljava/lang/String;
-	public final fun getSignatureSvg (ILjava/lang/Integer;)Ljava/lang/String;
-	public static synthetic fun getSignatureSvg$default (Lse/warting/signatureview/views/SignaturePad;ILjava/lang/Integer;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun getSignatureSvg (Ljava/lang/Integer;Ljava/lang/Integer;)Ljava/lang/String;
+	public static synthetic fun getSignatureSvg$default (Lse/warting/signatureview/views/SignaturePad;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Ljava/lang/String;
 	public final fun getTransparentSignatureBitmap (ZLjava/lang/Integer;)Landroid/graphics/Bitmap;
 	public static synthetic fun getTransparentSignatureBitmap$default (Lse/warting/signatureview/views/SignaturePad;ZLjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun isEmpty ()Z

--- a/signature-view/build.gradle.kts
+++ b/signature-view/build.gradle.kts
@@ -90,7 +90,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
         freeCompilerArgs = listOfNotNull(
             "-opt-in=kotlin.RequiresOptIn",
             "-Xskip-prerelease-check"
@@ -114,7 +114,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
@@ -207,6 +207,19 @@ class SignaturePad(context: Context, attrs: AttributeSet?) : View(context, attrs
         return signatureSDK.getSignatureSvg(width, height)
     }
 
+    /**
+     * Returns the current signature as an SVG document with optional coloring.
+     *
+     * @param penColor ARGB color of the signature stroke.
+     * @param backgroundColor ARGB color filled behind the signature. If null the SVG is transparent.
+     */
+    fun getSignatureSvg(
+        @ColorInt penColor: Int,
+        @ColorInt backgroundColor: Int? = null,
+    ): String {
+        return signatureSDK.getSignatureSvg(width, height, penColor, backgroundColor)
+    }
+
     @ExperimentalSignatureApi
     fun getSignature(): Signature {
         return Signature(BuildConfig.VERSION_CODE, signatureSDK.getEvents())

--- a/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
@@ -210,11 +210,11 @@ class SignaturePad(context: Context, attrs: AttributeSet?) : View(context, attrs
     /**
      * Returns the current signature as an SVG document with optional coloring.
      *
-     * @param penColor ARGB color of the signature stroke.
+     * @param penColor ARGB color of the signature stroke. If null the stroke defaults to black.
      * @param backgroundColor ARGB color filled behind the signature. If null the SVG is transparent.
      */
     fun getSignatureSvg(
-        @ColorInt penColor: Int,
+        @ColorInt penColor: Int? = null,
         @ColorInt backgroundColor: Int? = null,
     ): String {
         return signatureSDK.getSignatureSvg(width, height, penColor, backgroundColor)


### PR DESCRIPTION
Tracked by [#285](https://github.com/warting/android-signaturepad/issues/285)

## This PR...

Adds optional `penColor` and `backgroundColor` parameters to `getSignatureSvg()`, mirroring the bitmap coloring API introduced in #372 so users can produce colored SVG exports rather than only black-on-transparent.

## Considerations and implementation

- New overload `SignatureSDK.getSignatureSvg(width, height, penColor: Int?, backgroundColor: Int? = null)` plus matching overloads on `SignaturePad` (View) and `SignaturePadAdapter` (Compose). The original zero-arg `getSignatureSvg()` is preserved with its existing behavior (black stroke, transparent background) so this change is fully backwards-compatible at both source and binary level.
- ARGB ints are decomposed into `#RRGGBB` plus a separate `stroke-opacity` / `fill-opacity` attribute when alpha < 0xFF. This keeps the SVG compatible with SVG 1.2 Tiny (the profile already declared in the document header) which doesn't support `#RRGGBBAA`.
- Background, when non-null, is rendered as a `<rect width="100%" height="100%" .../>` placed before the path group.
- Public API dumps for all three artifacts are updated.

This PR also bundles a small environment refresh (separate commit):
- Kotlin/Java toolchain bumped from 17 to 21 across all four modules. The `foojay-resolver-convention` plugin in `settings.gradle.kts` auto-provisions the JDK, so contributors don't need to install anything manually.
- `app/lint-baseline.xml` regenerated under lint 8.13.1 (matches the AGP version already in use). The previous baseline still pointed at lint `7.4.0-beta04` from the pre-AGP-8 era, so it had stale entries (`KtxExtensionAvailable` for a line that no longer exists) and was missing the `Instantiatable` false positive that lint 8.13 produces for `FragmentActivity`-based `MainActivity`.
- `CLAUDE.md` updated to reference JDK 21.

### How to test

1. Open the demo app and navigate to the Compose sample.
2. Pick a stroke color, draw a signature, then enable **Use override colors** and tap **Save**.
3. Inspect the rendered SVG textbox under the bitmap previews — the stroke should match the *Image pen color* toggle and the SVG should have a colored background matching the *Image background color* toggle.
4. Toggle **Use override colors** off and Save again — the SVG should fall back to the original black-on-transparent output.
5. `./gradlew check` passes locally on JDK 21.

### Test(s) added

`SvgBuilderTest` (new JVM unit tests in `signature-core`) covers:
- default fallback emits `stroke="black"` and no background rect
- opaque pen color → `#RRGGBB` and no `stroke-opacity`
- translucent pen color → `#RRGGBB` plus `stroke-opacity`
- background color emits a `<rect>` placed before `<g>`
- translucent background → `fill-opacity`
- output is deterministic for the same inputs

Visual changes are limited to the demo app's existing color toggles now also affecting the SVG output; no new UI was added.

### Screenshots

| Before | After |
| ------ | ----- |
| Stroke is always black, no background | Stroke and background respect the toggles in the Compose sample |