### PR TITLE
Bump AGP to 9.2, Kotlin to 2.3, Gradle wrapper to 9.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,8 @@ signature-pad (Compose) ──api──> signature-core
 - **Version catalog**: `gradle/libs.versions.toml` for all dependency versions
 - **JDK 21** required (configured via `jvmToolchain(21)`, auto-provisioned via the `foojay-resolver-convention` plugin in `settings.gradle.kts`)
 - **compileSdk 36**, **minSdk 23**
-- **Kotlin 2.2.x** with Compose compiler plugin
-- **AGP** (Android Gradle Plugin) 8.13.x
+- **Kotlin 2.3.x** with Compose compiler plugin
+- **AGP** (Android Gradle Plugin) 9.2.x (Gradle 9.4.1+)
 
 ### Common Build Commands
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,18 +30,12 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
         }
-    }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
-        freeCompilerArgs = listOfNotNull(
-            "-opt-in=kotlin.RequiresOptIn",
-            "-Xskip-prerelease-check"
-        )
     }
     buildFeatures {
         compose = true
@@ -69,10 +63,6 @@ android {
         sarifOutput = file("../lint-results-lib.sarif")
     }
     namespace = "se.warting.signaturepad.app"
-}
-
-kotlin {
-    jvmToolchain(21)
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,3 +70,18 @@ detekt {
         html.enabled = true
     }
 }
+
+subprojects {
+    plugins.withId("org.jetbrains.kotlin.android") {
+        extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension> {
+            jvmToolchain(21)
+            compilerOptions {
+                jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+                freeCompilerArgs.addAll(
+                    "-opt-in=kotlin.RequiresOptIn",
+                    "-Xskip-prerelease-check",
+                )
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,9 @@ kotlin.code.style=official
 org.gradle.caching=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
+
+# AGP 9 migration: keep using kotlin-android + kapt for now. The proper
+# migration to AGP's built-in Kotlin support and KSP for data binding
+# can land in a follow-up PR.
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-agp = "8.13.1"
+agp = "9.2.0"
 androidx-activity = "1.13.0"
 composeBom = "2026.04.01"
 core = "1.18.0"
 io-gitlab-arturbosch-detekt = "1.23.8"
-kotlin = "2.2.21"
+kotlin = "2.3.21"
 navigation3UiAndroid = "1.2.0-alpha02"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/signature-core/build.gradle.kts
+++ b/signature-core/build.gradle.kts
@@ -78,13 +78,6 @@ android {
         compose = true
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
-        freeCompilerArgs = listOfNotNull(
-            "-opt-in=kotlin.RequiresOptIn",
-            "-Xskip-prerelease-check"
-        )
-    }
     lint {
         baseline = file("lint-baseline.xml")
         checkReleaseBuilds = true
@@ -100,10 +93,6 @@ android {
         sarifOutput = file("../lint-results-signature-core.sarif")
     }
     namespace = "se.warting.signaturepad.core"
-}
-
-kotlin {
-    jvmToolchain(21)
 }
 
 dependencies {

--- a/signature-pad/build.gradle.kts
+++ b/signature-pad/build.gradle.kts
@@ -75,13 +75,6 @@ android {
         compose = true
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
-        freeCompilerArgs = listOfNotNull(
-            "-opt-in=kotlin.RequiresOptIn",
-            "-Xskip-prerelease-check"
-        )
-    }
     lint {
         baseline = file("lint-baseline.xml")
         checkReleaseBuilds = true
@@ -97,10 +90,6 @@ android {
         sarifOutput = file("../lint-results-signature-pad.sarif")
     }
     namespace = "se.warting.signaturepad.compose"
-}
-
-kotlin {
-    jvmToolchain(21)
 }
 
 dependencies {

--- a/signature-view/build.gradle.kts
+++ b/signature-view/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
     alias(libs.plugins.kotlin.android)
     id("maven-publish")
     id("signing")
-    id("org.jetbrains.dokka") version "2.1.0"
-    id("com.gladed.androidgitversion") version "0.4.14"
+    alias(libs.plugins.org.jetbrains.dokka)
+    alias(libs.plugins.com.gladed.androidgitversion)
     id("kotlin-kapt")
     alias(libs.plugins.io.gitlab.arturbosch.detekt)
     alias(libs.plugins.com.vanniktech.maven.publish)
@@ -89,13 +89,6 @@ android {
         enable = true
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
-        freeCompilerArgs = listOfNotNull(
-            "-opt-in=kotlin.RequiresOptIn",
-            "-Xskip-prerelease-check"
-        )
-    }
     lint {
         baseline = file("lint-baseline.xml")
         checkReleaseBuilds = true
@@ -111,10 +104,6 @@ android {
         sarifOutput = file("../lint-results-signature-view.sarif")
     }
     namespace = "se.warting.signaturepad.view"
-}
-
-kotlin {
-    jvmToolchain(21)
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
Follow-up to [#474](https://github.com/warting/android-signaturepad/pull/474), which deferred these majors because they require a coupled toolchain migration that didn't belong in a dependency refresh.

## Toolchain bumps
- **AGP 8.13.1 → 9.2.0** (per Copilot's note on #474)
- **Kotlin 2.2.21 → 2.3.21**
- **Gradle wrapper 8.14.1 → 9.4.1** (AGP 9 minimum)

## Build-script changes required by the bumps
- Removed `kotlinOptions { ... }` blocks (no longer present on the Android extension in AGP 9) and re-expressed them via the `kotlin.compilerOptions { ... }` DSL in `app`, `signature-core`, `signature-pad`, and `signature-view`.
- Enabled `isShrinkResources = true` on the app release buildType — AGP 9's lint now errors (`NotShrinkingResources`) when minification is on without resource shrinking.

## Deferred: built-in Kotlin / KSP migration
AGP 9 ships built-in Kotlin support that's incompatible with `kotlin-android` and `kotlin-kapt`. Removing both is a larger refactor — we'd need to move data binding (`@BindingAdapter`s in `signature-view`, plus `DataBindingSampleFragment` in the app) onto KSP. To keep this PR scoped to the toolchain bump, this PR opts out via the documented flags:

```properties
# gradle.properties
android.builtInKotlin=false
android.newDsl=false
```

The KSP / built-in-Kotlin migration can land in a follow-up.

## Test plan
- [x] `./gradlew check` passes locally
- [ ] CI `build` job passes