### PR TITLE
Add undo support for the last stroke

### DIFF
--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -94,10 +94,12 @@ private fun ColorToggleGroup(
 @Composable
 private fun SaveClearRow(
     onSave: () -> Unit,
-    onClear: () -> Unit
+    onClear: () -> Unit,
+    onUndo: () -> Unit
 ) {
     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         Button(modifier = Modifier.weight(1f), onClick = onSave) { Text("Save") }
+        Button(modifier = Modifier.weight(1f), onClick = onUndo) { Text("Undo") }
         Button(modifier = Modifier.weight(1f), onClick = onClear) { Text("Clear") }
     }
 }
@@ -204,6 +206,9 @@ fun ComposeSample() {
             onClear = {
                 svg = ""
                 adapter?.clear()
+            },
+            onUndo = {
+                adapter?.undo()
             }
         )
 

--- a/app/src/main/java/se/warting/signaturepad/app/ViewFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ViewFragment.kt
@@ -18,6 +18,7 @@ class ViewFragment : Fragment() {
 
     private lateinit var mSaveButton: Button
     private lateinit var mClearButton: Button
+    private lateinit var mUndoButton: Button
     private lateinit var mSignaturePad: SignaturePad
 
     override fun onCreateView(
@@ -48,6 +49,7 @@ class ViewFragment : Fragment() {
 
         mSaveButton = view.findViewById<View>(R.id.save_button) as Button
         mClearButton = view.findViewById<View>(R.id.clear_button) as Button
+        mUndoButton = view.findViewById<View>(R.id.undo_button) as Button
         mSignaturePad = view.findViewById<View>(R.id.signature_pad) as SignaturePad
 
         mSignaturePad.setOnSignedListener(object : SignedListener {
@@ -64,6 +66,7 @@ class ViewFragment : Fragment() {
                 Log.d("SignedListener", "OnSigned")
                 mSaveButton.isEnabled = !mSignaturePad.isEmpty
                 mClearButton.isEnabled = !mSignaturePad.isEmpty
+                mUndoButton.isEnabled = mSignaturePad.canUndo()
             }
 
             override fun onClear() {
@@ -73,10 +76,12 @@ class ViewFragment : Fragment() {
 
                 mSaveButton.isEnabled = !mSignaturePad.isEmpty
                 mClearButton.isEnabled = !mSignaturePad.isEmpty
+                mUndoButton.isEnabled = mSignaturePad.canUndo()
             }
         })
 
         mClearButton.setOnClickListener { mSignaturePad.clear() }
+        mUndoButton.setOnClickListener { mSignaturePad.undo() }
         mSaveButton.setOnClickListener {
             val signatureBitmap = mSignaturePad.getSignatureBitmap()
             val signatureSvg = mSignaturePad.getSignatureSvg()

--- a/app/src/main/res/layout/activity_view.xml
+++ b/app/src/main/res/layout/activity_view.xml
@@ -60,6 +60,15 @@
 
         <Button
             style="?android:attr/buttonBarButtonStyle"
+            android:id="@+id/undo_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:enabled="false"
+            android:text="@string/undo" />
+
+        <Button
+            style="?android:attr/buttonBarButtonStyle"
             android:id="@+id/save_button"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,5 +2,6 @@
     <string name="app_name">Signaturepad</string>
     <string name="agreement">I agree the terms and conditions.</string>
     <string name="clear_pad">Clear Pad</string>
+    <string name="undo">Undo</string>
     <string name="save_signature">Save Signature</string>
 </resources>

--- a/signature-core/api/signature-core.api
+++ b/signature-core/api/signature-core.api
@@ -49,6 +49,7 @@ public final class se/warting/signaturecore/SignatureSDK {
 	public static final field DEFAULT_ATTR_VELOCITY_FILTER_WEIGHT F
 	public fun <init> ()V
 	public final fun addEvent (Lse/warting/signaturecore/Event;)V
+	public final fun canUndo ()Z
 	public final fun clear ()V
 	public final fun configure (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;)V
 	public static synthetic fun configure$default (Lse/warting/signaturecore/SignatureSDK;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;ILjava/lang/Object;)V
@@ -64,6 +65,7 @@ public final class se/warting/signaturecore/SignatureSDK {
 	public final fun isEmpty ()Z
 	public final fun restoreEvents (Ljava/util/List;)V
 	public final fun setOnSignedListener (Lse/warting/signaturecore/utils/SignedListener;)V
+	public final fun undo ()V
 }
 
 public final class se/warting/signaturecore/SignatureSDK$Companion {

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -198,6 +198,25 @@ class SignatureSDK {
         }
     }
 
+    /**
+     * Returns true when there is at least one completed or in-progress stroke
+     * that can be removed by [undo].
+     */
+    fun canUndo(): Boolean = originalEvents.any { it.action == MotionEvent.ACTION_DOWN }
+
+    /**
+     * Removes the last stroke (the events from the most recent
+     * [MotionEvent.ACTION_DOWN] through the end of the event list) and
+     * redraws the signature. No-op when there is no stroke to undo.
+     */
+    fun undo() {
+        val lastDown = originalEvents.indexOfLast { it.action == MotionEvent.ACTION_DOWN }
+        if (lastDown < 0) return
+        val remaining = originalEvents.subList(0, lastDown).toList()
+        restoreEvents(remaining)
+        notifyListeners()
+    }
+
     fun getEvents(): List<Event> {
         return originalEvents.toList()
     }

--- a/signature-pad/api/signature-pad.api
+++ b/signature-pad/api/signature-pad.api
@@ -1,6 +1,7 @@
 public final class se/warting/signaturepad/SignaturePadAdapter {
 	public static final field $stable I
 	public fun <init> (Lse/warting/signatureview/views/SignaturePad;)V
+	public final fun canUndo ()Z
 	public final fun clear ()V
 	public final fun getSignature ()Lse/warting/signaturecore/Signature;
 	public final fun getSignatureBitmap ()Landroid/graphics/Bitmap;
@@ -11,6 +12,7 @@ public final class se/warting/signaturepad/SignaturePadAdapter {
 	public static synthetic fun getTransparentSignatureBitmap$default (Lse/warting/signaturepad/SignaturePadAdapter;ZLjava/lang/Integer;ILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public final fun isEmpty ()Z
 	public final fun setSignature (Lse/warting/signaturecore/Signature;)V
+	public final fun undo ()V
 }
 
 public final class se/warting/signaturepad/SignaturePadViewKt {

--- a/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
+++ b/signature-pad/src/main/java/se/warting/signaturepad/SignaturePadView.kt
@@ -70,6 +70,18 @@ class SignaturePadAdapter(private val signaturePad: SignaturePad) {
         signaturePad.clear()
     }
 
+    /**
+     * Undo the last stroke. Has no effect when there is nothing to undo.
+     */
+    fun undo() {
+        signaturePad.undo()
+    }
+
+    /**
+     * @return true if a stroke is available to undo.
+     */
+    fun canUndo(): Boolean = signaturePad.canUndo()
+
     val isEmpty: Boolean
         get() = signaturePad.isEmpty
 

--- a/signature-view/api/signature-view.api
+++ b/signature-view/api/signature-view.api
@@ -66,6 +66,7 @@ public final class se/warting/signatureview/view/ViewCompat {
 
 public final class se/warting/signatureview/views/SignaturePad : android/view/View {
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public final fun canUndo ()Z
 	public final fun clear ()V
 	public final fun clearView ()V
 	public final fun getSignature ()Lse/warting/signaturecore/Signature;
@@ -85,5 +86,6 @@ public final class se/warting/signatureview/views/SignaturePad : android/view/Vi
 	public final fun setPenColorRes (I)V
 	public final fun setSignature (Lse/warting/signaturecore/Signature;)V
 	public final fun setVelocityFilterWeight (F)V
+	public final fun undo ()V
 }
 

--- a/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
@@ -157,6 +157,19 @@ class SignaturePad(context: Context, attrs: AttributeSet?) : View(context, attrs
         clearView()
     }
 
+    /**
+     * Undo the last stroke. Has no effect when there is nothing to undo.
+     */
+    fun undo() {
+        signatureSDK.undo()
+        invalidate()
+    }
+
+    /**
+     * @return true if a stroke is available to undo.
+     */
+    fun canUndo(): Boolean = signatureSDK.canUndo()
+
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
         val didDoubleClick = doubleClickGestureDetector.onTouchEvent(event)


### PR DESCRIPTION
Tracked by [#354](https://github.com/warting/android-signaturepad/issues/354)

## This PR...

Adds `undo()` / `canUndo()` to the signature pad so callers can remove the last drawn stroke and have the canvas redrawn from the remaining strokes.

## Considerations and implementation

- The SDK already records every touch event in `originalEvents`. Undo locates the most recent `ACTION_DOWN`, drops everything from that index onward, and reuses the existing `restoreEvents()` machinery to clear the bitmap and SVG and replay the surviving events. This keeps the rendering path identical to the save/restore flow.
- The new API is exposed on all three public surfaces:
  - `SignatureSDK.undo()` / `SignatureSDK.canUndo()`
  - `SignaturePad.undo()` / `SignaturePad.canUndo()` (View)
  - `SignaturePadAdapter.undo()` / `SignaturePadAdapter.canUndo()` (Compose)
- Binary-compatibility validator dumps were updated for `signature-core`, `signature-view`, and `signature-pad`.
- After undo, `notifyListeners()` is invoked so existing `onSigned`/`onClear` consumers stay in sync (no new callback was added — kept `SignedListener` source-compatible).

### How to test

1. Run the demo `app` module and open either the View sample or the Compose sample.
2. Draw multiple strokes (lift the finger between each).
3. Tap **Undo** — the most recent stroke disappears; repeat to peel back further. After the last stroke is undone the pad is empty (`onClear` fires in the View sample).
4. `./gradlew check` — passes (lint, detekt, apiCheck).

### Test(s) added

No automated tests added — the project currently has no SDK-level unit tests for stroke replay (the rendering path requires Android `Canvas`/`Bitmap`), and adding a Robolectric/instrumented harness was out of scope. The change reuses the well-exercised `restoreEvents()` path, and the demo app provides an interactive smoke test.

### Screenshots

| Before | After |
| ------ | ----- |
| _no undo affordance_ | _Undo button removes the last stroke_ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)