### PR TITLE
Fix wrong key when restoring SignaturePad super state

### DIFF
--- a/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
@@ -73,10 +73,10 @@ class SignaturePad(context: Context, attrs: AttributeSet?) : View(context, attrs
 
             mutableState =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    state.getParcelable("events", Parcelable::class.java)
+                    state.getParcelable("superState", Parcelable::class.java)
                 } else {
                     @Suppress("DEPRECATION")
-                    state.getParcelable("events")
+                    state.getParcelable("superState")
                 }
             invalidate()
         }


### PR DESCRIPTION
## Summary

`SignaturePad.onRestoreInstanceState` reads the super state from the wrong Bundle key. `onSaveInstanceState` stores it under `"superState"` ([SignaturePad.kt:55](signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt#L55)), but restore reads `"events"` ([SignaturePad.kt:76,79](signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt#L76-L79)) — which is the events array, not a Parcelable.

The mismatch means the View's super state (ID, scroll, etc.) is silently never restored:
- API 33+: `Bundle.getParcelable(key, Class)` catches the resulting `ClassCastException` and returns `null` with a `typeWarning` log.
- Pre-33: the deprecated cast can throw on some devices.

This is a separate issue from the R8 obfuscation crash fixed in #455.

Spotted by Gemini/ChatGPT analysis posted in https://github.com/warting/android-signaturepad/issues/433.

## Test plan

- [ ] `./gradlew check` passes
- [ ] Manually verify state restore on a release build still works after #455's keep rule
- [ ] Confirm no `typeWarning` in logcat during state restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)