### PR TITLE
Drop non-finite touch coordinates to prevent SvgPoint crash

### DIFF
--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -44,6 +44,11 @@ class SignatureSDK {
     private var lastVelocity = 0f
     private var lastWidth = 0f
 
+    // Most recent finite touch coordinate. Used to substitute on a glitched
+    // ACTION_UP so the stroke still terminates cleanly.
+    private var lastValidX = 0f
+    private var lastValidY = 0f
+
     // SVG building
     private val svgBuilder = SvgBuilder()
 
@@ -101,10 +106,27 @@ class SignatureSDK {
         // Some devices/drivers occasionally deliver NaN or infinite touch
         // coordinates (e.g. palm rejection, stylus glitches). Propagating
         // those values produces NaN curve control points and crashes
-        // downstream in roundToInt(). Drop the sample at the input boundary.
-        if (!event.x.isFinite() || !event.y.isFinite()) return
-        originalEvents.add(event)
-        processCurrentEvent(event)
+        // downstream in roundToInt(). Filter at the input boundary.
+        val sanitized = sanitizeEvent(event) ?: return
+        originalEvents.add(sanitized)
+        processCurrentEvent(sanitized)
+    }
+
+    private fun sanitizeEvent(event: Event): Event? {
+        if (event.x.isFinite() && event.y.isFinite()) {
+            lastValidX = event.x
+            lastValidY = event.y
+            return event
+        }
+        // ACTION_DOWN and ACTION_MOVE are safe to drop — we just lose one
+        // sample. ACTION_UP must still be delivered or onSigned() never
+        // fires and the stroke is left dangling (undo state, originalEvents
+        // become inconsistent). Replay it with the last valid coordinate.
+        return if (event.action == MotionEvent.ACTION_UP) {
+            Event(event.timestamp, event.action, lastValidX, lastValidY)
+        } else {
+            null
+        }
     }
 
     private fun processCurrentEvent(event: Event) {

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -98,6 +98,11 @@ class SignatureSDK {
     }
 
     fun addEvent(event: Event) {
+        // Some devices/drivers occasionally deliver NaN or infinite touch
+        // coordinates (e.g. palm rejection, stylus glitches). Propagating
+        // those values produces NaN curve control points and crashes
+        // downstream in roundToInt(). Drop the sample at the input boundary.
+        if (!event.x.isFinite() || !event.y.isFinite()) return
         originalEvents.add(event)
         processCurrentEvent(event)
     }

--- a/signature-core/src/main/java/se/warting/signaturecore/utils/SvgBuilder.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/utils/SvgBuilder.kt
@@ -128,12 +128,12 @@ class SvgBuilder {
         val rounded = (alpha * 1000f).roundToInt() / 1000f
         return rounded.toString().trimEnd('0').trimEnd('.').ifEmpty { "0" }
     }
+
+    private fun TimedPoint.hasFiniteCoordinates(): Boolean = x.isFinite() && y.isFinite()
+
+    private fun Bezier.hasFiniteCoordinates(): Boolean =
+        startPoint.hasFiniteCoordinates() &&
+            control1.hasFiniteCoordinates() &&
+            control2.hasFiniteCoordinates() &&
+            endPoint.hasFiniteCoordinates()
 }
-
-internal fun TimedPoint.hasFiniteCoordinates(): Boolean = x.isFinite() && y.isFinite()
-
-internal fun Bezier.hasFiniteCoordinates(): Boolean =
-    startPoint.hasFiniteCoordinates() &&
-        control1.hasFiniteCoordinates() &&
-        control2.hasFiniteCoordinates() &&
-        endPoint.hasFiniteCoordinates()

--- a/signature-core/src/main/java/se/warting/signaturecore/utils/SvgBuilder.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/utils/SvgBuilder.kt
@@ -53,6 +53,12 @@ class SvgBuilder {
     }
 
     fun append(curve: Bezier, strokeWidth: Float): SvgBuilder {
+        // Defensive guard against NaN/infinite coordinates leaking through to
+        // SvgPoint, where roundToInt() would throw IllegalArgumentException.
+        // The primary filter lives at the input boundary (SignatureSDK.addEvent),
+        // but skipping a curve here is cheaper than crashing if any internal
+        // arithmetic ever produces a non-finite value.
+        if (!curve.hasFiniteCoordinates() || !strokeWidth.isFinite()) return this
         val roundedStrokeWidth: Int = strokeWidth.roundToInt()
         val curveStartSvgPoint = SvgPoint(curve.startPoint)
         val curveControlSvgPoint1 = SvgPoint(curve.control1)
@@ -123,3 +129,11 @@ class SvgBuilder {
         return rounded.toString().trimEnd('0').trimEnd('.').ifEmpty { "0" }
     }
 }
+
+internal fun TimedPoint.hasFiniteCoordinates(): Boolean = x.isFinite() && y.isFinite()
+
+internal fun Bezier.hasFiniteCoordinates(): Boolean =
+    startPoint.hasFiniteCoordinates() &&
+        control1.hasFiniteCoordinates() &&
+        control2.hasFiniteCoordinates() &&
+        endPoint.hasFiniteCoordinates()

--- a/signature-core/src/test/java/se/warting/signaturecore/utils/SvgBuilderTest.kt
+++ b/signature-core/src/test/java/se/warting/signaturecore/utils/SvgBuilderTest.kt
@@ -82,6 +82,33 @@ class SvgBuilderTest {
     }
 
     @Test
+    fun append_skipsCurveWithNonFiniteCoordinates() {
+        val builder = SvgBuilder()
+
+        // A NaN coordinate anywhere in the curve must not crash the builder.
+        // Regression test for issue #336 — previously SvgPoint.<init> threw
+        // IllegalArgumentException("Cannot round NaN value") when downstream
+        // arithmetic produced NaN/Inf for a control point.
+        builder.append(makeBezier(0f, 0f, Float.NaN, 0f, 10f, 5f, 15f, 10f), strokeWidth = 4f)
+        builder.append(makeBezier(0f, 0f, 5f, 0f, 10f, 5f, 15f, Float.POSITIVE_INFINITY), strokeWidth = 4f)
+        builder.append(makeBezier(0f, 0f, 5f, 0f, 10f, 5f, 15f, 10f), strokeWidth = Float.NaN)
+
+        val svg = builder.build(width = 50, height = 50, penColor = null, backgroundColor = null)
+        assertFalse("Skipped curves must not emit a <path>", svg.contains("<path "))
+    }
+
+    @Test
+    fun append_emitsPathWhenCurveIsValidAfterSkippedOne() {
+        val builder = SvgBuilder().apply {
+            append(makeBezier(Float.NaN, 0f, 5f, 0f, 10f, 5f, 15f, 10f), strokeWidth = 4f)
+            append(makeBezier(0f, 0f, 5f, 0f, 10f, 5f, 15f, 10f), strokeWidth = 4f)
+        }
+
+        val svg = builder.build(width = 50, height = 50, penColor = null, backgroundColor = null)
+        assertTrue("Valid curve should still produce a <path>", svg.contains("<path "))
+    }
+
+    @Test
     fun build_isIdempotentWithAppendedCurves() {
         val builder = SvgBuilder().apply {
             append(makeBezier(0f, 0f, 5f, 0f, 10f, 5f, 15f, 10f), strokeWidth = 4f)


### PR DESCRIPTION
## Summary

- Fixes the random `IllegalArgumentException: Cannot round NaN value` crash reported in #336, where `SvgPoint.<init>` calls `roundToInt()` on a NaN coordinate during signature drawing.
- Filters at the input boundary in `SignatureSDK.addEvent` so a touch event with NaN or infinite x/y is dropped before it can enter the curve math.
- Adds a defensive skip in `SvgBuilder.append` that no-ops when any control point or stroke width is non-finite. This is the exact layer that throws today, so even if a future internal computation produces a NaN it won't crash the consumer.

## Why two layers

The reported crash chain is `onTouchEvent` → `addEvent` → `addTimedPoint` → `addBezier` → `SvgBuilder.append` → `SvgPoint.<init>` → `roundToInt`. The most likely origin is a bad `MotionEvent` (palm rejection, stylus driver glitch), which is fixed at the input boundary. The `SvgBuilder` guard is cheap insurance against any other NaN source — `calculateCurveControlPoints` already had to add a `k.isNaN()` workaround for a division, so the math is known to be NaN-prone.

This protects both the legacy View (`signature-view`) and the Compose (`signature-pad`) consumers, since both ultimately route touch input through `SignatureSDK.addEvent`.

## Alternative considered

PR #365 added `require(...)` checks that throw `IllegalArgumentException` with richer error messages. That improves diagnostics but does not stop the crash — same exception type, same outcome for the user. This PR drops the bad sample silently instead, which is the right behavior at a touch boundary.

## Test plan

- [x] `./gradlew check` (lint + detekt + tests) passes locally on JDK 21
- [x] New unit tests in `SvgBuilderTest`:
  - `append_skipsCurveWithNonFiniteCoordinates` — feeds NaN x, +Infinity y, and NaN strokeWidth into `append()` and asserts no `<path>` is emitted and no exception is thrown (regression test against the SvgPoint crash).
  - `append_emitsPathWhenCurveIsValidAfterSkippedOne` — verifies that a valid curve following a skipped one still produces output, i.e. the builder isn't poisoned by a bad input.
- No public API changes (no `apiDump` needed).

Fixes #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)