### PR TITLE
Demo dynamic pen width via sliders in Compose sample

### DIFF
--- a/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
+++ b/app/src/main/java/se/warting/signaturepad/app/ComposeFragment.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,6 +44,10 @@ import se.warting.signaturepad.SignaturePadAdapter
 import se.warting.signaturepad.SignaturePadView
 
 private const val SIGNATURE_PAD_HEIGHT_DP = 120
+private const val PEN_WIDTH_MIN_DP = 1f
+private const val PEN_WIDTH_MAX_DP = 20f
+private const val DEFAULT_PEN_MIN_WIDTH_DP = 3f
+private const val DEFAULT_PEN_MAX_WIDTH_DP = 7f
 
 @Composable
 private fun ColorToggleGroup(
@@ -150,6 +155,8 @@ fun ComposeSample() {
     )
 
     var useOverride by remember { mutableStateOf(false) }
+    var penMinWidth by remember { mutableStateOf(DEFAULT_PEN_MIN_WIDTH_DP) }
+    var penMaxWidth by remember { mutableStateOf(DEFAULT_PEN_MAX_WIDTH_DP) }
 
     Column(
         Modifier
@@ -166,6 +173,8 @@ fun ComposeSample() {
             SignaturePadView(
                 onReady = { adapter = it },
                 penColor = toggles[0].state.value,
+                penMinWidth = penMinWidth.dp,
+                penMaxWidth = penMaxWidth.dp,
                 onStartSigning = { Log.d("SignedListener", "onStartSigning") },
                 onSigning = { Log.d("SignedListener", "onSigning") },
                 onSigned = { Log.d("SignedListener", "onSigned") },
@@ -179,6 +188,32 @@ fun ComposeSample() {
             ColorToggleGroup(tol.title, tol.options, tol.state.value) { tol.state.value = it }
             Spacer(Modifier.height(8.dp))
         }
+
+        Text(
+            "Pen min width: ${"%.1f".format(penMinWidth)} dp",
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Slider(
+            value = penMinWidth,
+            onValueChange = {
+                penMinWidth = it
+                if (penMaxWidth < it) penMaxWidth = it
+            },
+            valueRange = PEN_WIDTH_MIN_DP..PEN_WIDTH_MAX_DP,
+        )
+        Text(
+            "Pen max width: ${"%.1f".format(penMaxWidth)} dp",
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Slider(
+            value = penMaxWidth,
+            onValueChange = {
+                penMaxWidth = it
+                if (penMinWidth > it) penMinWidth = it
+            },
+            valueRange = PEN_WIDTH_MIN_DP..PEN_WIDTH_MAX_DP,
+        )
+        Spacer(Modifier.height(8.dp))
 
         Row(
             Modifier


### PR DESCRIPTION
## Summary

Closes #461.

The Compose `SignaturePadView` already accepts `penMinWidth` / `penMaxWidth` and updates the underlying view on recomposition, so wiring a Slider/SeekBar to dynamic stroke size already works out of the box — but the demo app didn't show it, which is why users keep asking how to do it.

This PR adds two Material3 `Slider`s to `ComposeSample` driven by `mutableStateOf` floats, with a small invariant that keeps min ≤ max as the user drags either slider.

No library code changes — the existing API was sufficient.

## Test plan

- [x] `./gradlew :app:assembleDebug` succeeds
- [x] `./gradlew :app:lintDebug` passes
- [ ] Run the demo app and confirm strokes drawn after moving the sliders use the new widths
- [ ] Verify min slider can't push above max and vice versa

🤖 Generated with [Claude Code](https://claude.com/claude-code)