### PR TITLE
Render Signature to bitmap or SVG without an adapter (#471)

### DIFF
--- a/signature-core/api/signature-core.api
+++ b/signature-core/api/signature-core.api
@@ -39,6 +39,15 @@ public final class se/warting/signaturecore/Signature : android/os/Parcelable {
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
+public final class se/warting/signaturecore/SignatureRenderingKt {
+	public static final fun toBitmap (Lse/warting/signaturecore/Signature;IIIIIIF)Landroid/graphics/Bitmap;
+	public static synthetic fun toBitmap$default (Lse/warting/signaturecore/Signature;IIIIIIFILjava/lang/Object;)Landroid/graphics/Bitmap;
+	public static final fun toSvg (Lse/warting/signaturecore/Signature;IILjava/lang/Integer;Ljava/lang/Integer;IIF)Ljava/lang/String;
+	public static synthetic fun toSvg$default (Lse/warting/signaturecore/Signature;IILjava/lang/Integer;Ljava/lang/Integer;IIFILjava/lang/Object;)Ljava/lang/String;
+	public static final fun toTransparentBitmap (Lse/warting/signaturecore/Signature;IIZIIIF)Landroid/graphics/Bitmap;
+	public static synthetic fun toTransparentBitmap$default (Lse/warting/signaturecore/Signature;IIZIIIFILjava/lang/Object;)Landroid/graphics/Bitmap;
+}
+
 public final class se/warting/signaturecore/SignatureSDK {
 	public static final field $stable I
 	public static final field Companion Lse/warting/signaturecore/SignatureSDK$Companion;

--- a/signature-core/build.gradle.kts
+++ b/signature-core/build.gradle.kts
@@ -78,6 +78,10 @@ android {
         compose = true
     }
 
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+
     lint {
         baseline = file("lint-baseline.xml")
         checkReleaseBuilds = true

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureRendering.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureRendering.kt
@@ -1,0 +1,113 @@
+package se.warting.signaturecore
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.annotation.ColorInt
+import androidx.core.graphics.createBitmap
+
+/**
+ * Renders this [Signature] into a [Bitmap] of the requested size without needing
+ * a `SignaturePadAdapter` or `SignaturePad` view instance.
+ *
+ * @param width Bitmap width in pixels.
+ * @param height Bitmap height in pixels.
+ * @param backgroundColor ARGB color drawn behind the signature.
+ * @param penColor ARGB color of the signature stroke.
+ * @param penMinWidth Minimum stroke width in pixels.
+ * @param penMaxWidth Maximum stroke width in pixels.
+ * @param velocityFilterWeight Smoothing weight applied to stroke velocity.
+ */
+@ExperimentalSignatureApi
+@Suppress("LongParameterList")
+fun Signature.toBitmap(
+    width: Int,
+    height: Int,
+    @ColorInt backgroundColor: Int = Color.WHITE,
+    @ColorInt penColor: Int = SignatureSDK.DEFAULT_ATTR_PEN_COLOR,
+    penMinWidth: Int = SignatureSDK.DEFAULT_ATTR_PEN_MIN_WIDTH_PX,
+    penMaxWidth: Int = SignatureSDK.DEFAULT_ATTR_PEN_MAX_WIDTH_PX,
+    velocityFilterWeight: Float = SignatureSDK.DEFAULT_ATTR_VELOCITY_FILTER_WEIGHT,
+): Bitmap {
+    val sdk = newConfiguredSdk(penMinWidth, penMaxWidth, penColor, velocityFilterWeight)
+    sdk.initializeBitmap(width, height)
+    sdk.restoreEvents(events)
+    return sdk.getSignatureBitmap(backgroundColor = backgroundColor)
+        ?: createBitmap(width, height).apply { eraseColor(backgroundColor) }
+}
+
+/**
+ * Renders this [Signature] into a transparent [Bitmap] without needing a
+ * `SignaturePadAdapter` or `SignaturePad` view instance.
+ *
+ * @param width Bitmap width in pixels.
+ * @param height Bitmap height in pixels.
+ * @param trimBlankSpace When true, the returned bitmap is cropped to the signature bounds.
+ * @param penColor ARGB color of the signature stroke.
+ * @param penMinWidth Minimum stroke width in pixels.
+ * @param penMaxWidth Maximum stroke width in pixels.
+ * @param velocityFilterWeight Smoothing weight applied to stroke velocity.
+ */
+@ExperimentalSignatureApi
+@Suppress("LongParameterList")
+fun Signature.toTransparentBitmap(
+    width: Int,
+    height: Int,
+    trimBlankSpace: Boolean = false,
+    @ColorInt penColor: Int = SignatureSDK.DEFAULT_ATTR_PEN_COLOR,
+    penMinWidth: Int = SignatureSDK.DEFAULT_ATTR_PEN_MIN_WIDTH_PX,
+    penMaxWidth: Int = SignatureSDK.DEFAULT_ATTR_PEN_MAX_WIDTH_PX,
+    velocityFilterWeight: Float = SignatureSDK.DEFAULT_ATTR_VELOCITY_FILTER_WEIGHT,
+): Bitmap {
+    val sdk = newConfiguredSdk(penMinWidth, penMaxWidth, penColor, velocityFilterWeight)
+    sdk.initializeBitmap(width, height)
+    sdk.restoreEvents(events)
+    return sdk.getTransparentSignatureBitmap(trimBlankSpace = trimBlankSpace)
+        ?: createBitmap(width, height)
+}
+
+/**
+ * Renders this [Signature] as an SVG document without needing a
+ * `SignaturePadAdapter` or `SignaturePad` view instance.
+ *
+ * @param width SVG canvas width in pixels.
+ * @param height SVG canvas height in pixels.
+ * @param penColor ARGB color of the signature stroke. When null the stroke defaults to black.
+ * @param backgroundColor ARGB color filled behind the signature. When null the SVG is transparent.
+ * @param penMinWidth Minimum stroke width in pixels.
+ * @param penMaxWidth Maximum stroke width in pixels.
+ * @param velocityFilterWeight Smoothing weight applied to stroke velocity.
+ */
+@ExperimentalSignatureApi
+@Suppress("LongParameterList")
+fun Signature.toSvg(
+    width: Int,
+    height: Int,
+    @ColorInt penColor: Int? = null,
+    @ColorInt backgroundColor: Int? = null,
+    penMinWidth: Int = SignatureSDK.DEFAULT_ATTR_PEN_MIN_WIDTH_PX,
+    penMaxWidth: Int = SignatureSDK.DEFAULT_ATTR_PEN_MAX_WIDTH_PX,
+    velocityFilterWeight: Float = SignatureSDK.DEFAULT_ATTR_VELOCITY_FILTER_WEIGHT,
+): String {
+    val sdk = newConfiguredSdk(
+        penMinWidth,
+        penMaxWidth,
+        penColor ?: SignatureSDK.DEFAULT_ATTR_PEN_COLOR,
+        velocityFilterWeight,
+    )
+    sdk.restoreEvents(events)
+    return sdk.getSignatureSvg(width, height, penColor, backgroundColor)
+}
+
+private fun newConfiguredSdk(
+    minWidth: Int,
+    maxWidth: Int,
+    @ColorInt penColor: Int,
+    velocityFilterWeight: Float,
+): SignatureSDK = SignatureSDK().also {
+    it.configure(
+        minWidth = minWidth,
+        maxWidth = maxWidth,
+        penColor = penColor,
+        velocityFilterWeight = velocityFilterWeight,
+    )
+}

--- a/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
+++ b/signature-core/src/main/java/se/warting/signaturecore/SignatureSDK.kt
@@ -182,19 +182,17 @@ class SignatureSDK {
 
         // Clear bitmap to prevent drawing artifacts
         if (signatureTransparentBitmap != null) {
-            // Get current dimensions
             val width = signatureTransparentBitmap!!.width
             val height = signatureTransparentBitmap!!.height
-
-            // Clear and reinitialize bitmap
             signatureTransparentBitmap = null
             signatureBitmapCanvas = null
             initializeBitmap(width, height)
+        }
 
-            // Process all events to recreate the signature with proper curves
-            if (!originalEvents.isEmpty()) {
-                forward()
-            }
+        // Process all events so both the bitmap (if any) and the SVG builder
+        // reflect the restored signature.
+        if (originalEvents.isNotEmpty()) {
+            forward()
         }
     }
 

--- a/signature-core/src/test/java/se/warting/signaturecore/SignatureRenderingTest.kt
+++ b/signature-core/src/test/java/se/warting/signaturecore/SignatureRenderingTest.kt
@@ -1,0 +1,68 @@
+package se.warting.signaturecore
+
+import android.view.MotionEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalSignatureApi::class)
+class SignatureRenderingTest {
+
+    @Test
+    fun toSvg_emptySignature_emitsEmptyGroup() {
+        val signature = Signature(versionCode = 1, events = emptyList())
+
+        val svg = signature.toSvg(width = 100, height = 50)
+
+        assertTrue("Expected SVG to start with xml declaration", svg.startsWith("<?xml"))
+        assertFalse("Empty signature should produce no <path>", svg.contains("<path "))
+    }
+
+    @Test
+    fun toSvg_withStroke_emitsPath() {
+        val signature = Signature(versionCode = 1, events = sampleStroke())
+
+        val svg = signature.toSvg(
+            width = 200,
+            height = 100,
+            penColor = 0xFF112233.toInt(),
+        )
+
+        assertTrue("Expected at least one <path> in SVG output", svg.contains("<path "))
+        assertTrue(svg.contains("stroke=\"#112233\""))
+    }
+
+    @Test
+    fun toSvg_includesBackgroundWhenSpecified() {
+        val signature = Signature(versionCode = 1, events = sampleStroke())
+
+        val svg = signature.toSvg(
+            width = 50,
+            height = 50,
+            backgroundColor = 0xFFFFFFFF.toInt(),
+        )
+
+        assertTrue("Expected <rect> background", svg.contains("<rect"))
+        assertTrue(svg.contains("fill=\"#FFFFFF\""))
+    }
+
+    @Test
+    fun toSvg_isStableForSameInput() {
+        val signature = Signature(versionCode = 1, events = sampleStroke())
+
+        val first = signature.toSvg(width = 200, height = 100)
+        val second = signature.toSvg(width = 200, height = 100)
+
+        assertEquals("Repeated rendering must produce identical SVG", first, second)
+    }
+
+    @Suppress("MagicNumber")
+    private fun sampleStroke(): List<Event> = listOf(
+        Event(timestamp = 0L, action = MotionEvent.ACTION_DOWN, x = 10f, y = 10f),
+        Event(timestamp = 16L, action = MotionEvent.ACTION_MOVE, x = 30f, y = 40f),
+        Event(timestamp = 32L, action = MotionEvent.ACTION_MOVE, x = 60f, y = 60f),
+        Event(timestamp = 48L, action = MotionEvent.ACTION_MOVE, x = 90f, y = 70f),
+        Event(timestamp = 64L, action = MotionEvent.ACTION_UP, x = 120f, y = 80f),
+    )
+}


### PR DESCRIPTION
Tracked by [#471](https://github.com/warting/android-signaturepad/issues/471)

## This PR...

Lets callers render a stored `Signature` to a bitmap or SVG without instantiating a `SignaturePad` view or holding onto a `SignaturePadAdapter`.

## Considerations and implementation

Adds three extension functions in `signature-core`:

- `Signature.toBitmap(width, height, ...)` — opaque bitmap
- `Signature.toTransparentBitmap(width, height, ..., trimBlankSpace = false)` — transparent bitmap, optional trim
- `Signature.toSvg(width, height, ...)` — SVG document

All are marked `@ExperimentalSignatureApi`, with defaults pulled from `SignatureSDK` constants (`DEFAULT_ATTR_PEN_MIN_WIDTH_PX`, `DEFAULT_ATTR_PEN_MAX_WIDTH_PX`, `DEFAULT_ATTR_PEN_COLOR`, `DEFAULT_ATTR_VELOCITY_FILTER_WEIGHT`). Sizes are in pixels — Compose users handle dp→px themselves with `density.roundToPx(dp)`. The `signature-core` API dump is updated.

While wiring this up I hit a latent bug: `SignatureSDK.restoreEvents()` only called `forward()` when a bitmap was already allocated, which meant the `SvgBuilder` stayed empty when a `Signature` was restored without first initializing a bitmap. The new SVG path needs the events processed regardless of whether a bitmap exists, so `restoreEvents` now always replays events. The bitmap reset path is unchanged.

`signature-core/build.gradle.kts` enables `testOptions.unitTests.isReturnDefaultValues = true` because `SignatureSDK`'s constructor touches `Paint`, which throws under the JVM android.jar stubs without it.

### How to test

1. Get a `Signature` via `SignaturePadAdapter.getSignature()` (or build one from saved `Event`s).
2. Without any view in scope, call `signature.toBitmap(width, height, penColor = ..., backgroundColor = ...)` / `signature.toTransparentBitmap(...)` / `signature.toSvg(...)` and verify the output matches what the pad would render.
3. `./gradlew :signature-core:testDebugUnitTest` runs the new SVG-path tests.

### Test(s) added

`SignatureRenderingTest` covers the SVG path (empty signature, non-empty stroke, background color, determinism). The bitmap variants are thin wrappers over `SignatureSDK.getSignatureBitmap` / `getTransparentSignatureBitmap`, which require a real Android runtime, so they're not covered by JVM unit tests — manual verification through the demo app is the path there.

### Screenshots

N/A — pure API addition, no UI change.