### PR TITLE
Fix Dokka publish failure on Android library 'release' source set

### DIFF
--- a/signature-core/build.gradle.kts
+++ b/signature-core/build.gradle.kts
@@ -52,6 +52,12 @@ androidGitVersion {
     tagPattern = "^v[0-9]+.*"
 }
 
+dokka {
+    dokkaSourceSets.matching { it.name == "release" }.configureEach {
+        suppress.set(true)
+    }
+}
+
 val PUBLISH_GROUP_ID: String by extra(rootProject.group as String)
 val PUBLISH_VERSION: String by extra(rootProject.version as String)
 

--- a/signature-pad/build.gradle.kts
+++ b/signature-pad/build.gradle.kts
@@ -51,6 +51,12 @@ androidGitVersion {
     tagPattern = "^v[0-9]+.*"
 }
 
+dokka {
+    dokkaSourceSets.matching { it.name == "release" }.configureEach {
+        suppress.set(true)
+    }
+}
+
 val PUBLISH_GROUP_ID: String by extra(rootProject.group as String)
 val PUBLISH_VERSION: String by extra(rootProject.version as String)
 

--- a/signature-view/build.gradle.kts
+++ b/signature-view/build.gradle.kts
@@ -51,6 +51,12 @@ androidGitVersion {
     tagPattern = "^v[0-9]+.*"
 }
 
+dokka {
+    dokkaSourceSets.matching { it.name == "release" }.configureEach {
+        suppress.set(true)
+    }
+}
+
 val PUBLISH_GROUP_ID: String by extra(rootProject.group as String)
 val PUBLISH_VERSION: String by extra(rootProject.version as String)
 


### PR DESCRIPTION
## Summary
- The `snapshot` workflow's `publishAllPublicationsToMavenCentralRepository` task has been failing on every push to `main` because `:signature-core:dokkaGeneratePublicationHtml` errors with: `Pre-generation validity check failed: Source sets 'androidJvm' and 'release' have the common source roots…`. Dokka 2.x requires every Kotlin file to belong to exactly one source set, but the Android library + per-variant publishing combination registers both `androidJvm` (Dokka's default) and `release` (the variant) with the same `src/main/java` files. Tracked upstream at [Kotlin/dokka#3701](https://github.com/Kotlin/dokka/issues/3701).
- Fix: in each publishable module (`signature-core`, `signature-pad`, `signature-view`), suppress the duplicate `release` Dokka source set so generation runs from `androidJvm` only. The two source sets had identical source roots, so the rendered docs are unchanged.
- This wasn't caught by PR CI because `pr.yml` only runs `./gradlew check`, which doesn't invoke the Dokka publish task. Snapshot publishes have been silently failing for months.

## Test plan
- [x] Reproduced the failure locally: `./gradlew :signature-core:dokkaGeneratePublicationHtml` errored with the same message as in [job 73679310148](https://github.com/warting/android-signaturepad/actions/runs/25137483787/job/73679310148).
- [x] After the fix, ran `./gradlew :signature-core:dokkaGeneratePublicationHtml :signature-pad:dokkaGeneratePublicationHtml :signature-view:dokkaGeneratePublicationHtml` — all green.
- [x] Ran the full publish pipeline via `:signature-core:publishToMavenLocal :signature-pad:publishToMavenLocal :signature-view:publishToMavenLocal` — succeeds.
- [x] Spot-checked the generated HTML for `signature-core` — `Signature`, `SignatureSDK`, and the new `toBitmap` / `toSvg` / `toTransparentBitmap` rendering helpers are all documented.
- [ ] Confirm `snapshot.yml` succeeds once this is merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)